### PR TITLE
Fix crash in compiled binaries when source files are unavailable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 > [!IMPORTANT]
 > This version is not released yet and is under active development.
 
+- Fix crash in compiled binaries (Nuitka, PyInstaller, cx_Freeze) caused by missing source files for docstring extraction.
 - Drop support for Python 3.10.
 - Remove all deprecated backward-compatibility aliases:
   - Remove `ALL_PLATFORM_IDS` (use `ALL_TRAIT_IDS`).


### PR DESCRIPTION
## Summary

- Fix `get_attribute_docstring()` to gracefully handle missing source files in compiled environments
- Return `None` instead of raising `FileNotFoundError` when `.py` files don't exist

## Problem

When `extra-platforms` is used in applications compiled with Nuitka (or similar tools like PyInstaller, cx_Freeze), the library crashes on import:

```
FileNotFoundError: [Errno 2] No such file or directory: '...\extra_platforms\architecture_data.py'
```

This happens because:
1. `_initialize_all_docstrings()` is called during module import
2. `get_attribute_docstring()` tries to read Python source files to extract attribute docstrings
3. In compiled binaries, `.py` files are compiled to C/bytecode and don't exist as readable text files

## Solution

Modify `get_attribute_docstring()` to:
1. Return `None` if `inspect.getsourcefile()` returns `None` (instead of raising)
2. Catch `FileNotFoundError` and `OSError` when reading the file and return `None`

This allows the library to function in compiled binaries, just without the dynamically-generated attribute docstrings (which are primarily useful for documentation/introspection anyway).

## Test plan

- [x] Verify the fix resolves the Nuitka binary crash in [kdeldycke/workflows](https://github.com/kdeldycke/workflows/actions/runs/21719177436/job/62647912321)


🤖 Generated with [Claude Code](https://claude.com/claude-code)