### PR TITLE
Format Python

### DIFF
--- a/docs/_ext/myst_docstrings.py
+++ b/docs/_ext/myst_docstrings.py
@@ -59,6 +59,7 @@ _FENCE_RE = re.compile(
 # [text](url) but not ![alt](url)
 _LINK_RE = re.compile(r"(?<!!)\[([^\]]+)\]\(([^)]+)\)")
 
+
 def _convert_link(match: re.Match) -> str:
     """Convert a markdown link to reST, stripping backticks from the label."""
     label = match.group(1).replace("`", "")
@@ -95,9 +96,7 @@ def _convert_fence(match: re.Match) -> str:
             # Preserve relative indentation within the body.
             stripped = line.lstrip()
             extra_spaces = len(line) - len(stripped) - len(indent)
-            converted_lines.append(
-                body_indent + " " * max(0, extra_spaces) + stripped
-            )
+            converted_lines.append(body_indent + " " * max(0, extra_spaces) + stripped)
         else:
             converted_lines.append("")
 

--- a/tests/test_myst_docstrings.py
+++ b/tests/test_myst_docstrings.py
@@ -266,8 +266,7 @@ def test_real_detection_function():
     assert ":data:`~extra_platforms.ANDROID`" in result
     assert ".. seealso::" in result
     assert (
-        "    `kivy/utils.py"
-        " <https://github.com/kivy/kivy/blob/master/kivy/utils.py>`_"
+        "    `kivy/utils.py <https://github.com/kivy/kivy/blob/master/kivy/utils.py>`_"
     ) in result
 
 
@@ -309,7 +308,6 @@ def test_real_caution_with_code_block():
     assert ":data:`True`" in result
     assert ".. caution::" in result
     assert (
-        "    ``platform.machine()`` returns different values"
-        " depending on the OS:"
+        "    ``platform.machine()`` returns different values depending on the OS:"
     ) in result
     assert "    - Linux: ``aarch64``" in result


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`3423b9c9`](https://github.com/kdeldycke/extra-platforms/commit/3423b9c9dbb0549749e6001623fa1cf275738f83) |
| **Job** | [`format-python`](https://github.com/kdeldycke/extra-platforms/blob/3423b9c9dbb0549749e6001623fa1cf275738f83/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/extra-platforms/blob/3423b9c9dbb0549749e6001623fa1cf275738f83/.github/workflows/autofix.yaml) |
| **Run** | [#699.1](https://github.com/kdeldycke/extra-platforms/actions/runs/24660973476) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.13.0`