### PR TITLE
Format Python

### DIFF
--- a/tests/test_sphinx_crossrefs.py
+++ b/tests/test_sphinx_crossrefs.py
@@ -245,9 +245,7 @@ def test_rendered_links_point_to_correct_targets(
     )
 
 
-def _extract_reference_table_rows(
-    html: str, myst: str
-) -> tuple[str, str, str]:
+def _extract_reference_table_rows(html: str, myst: str) -> tuple[str, str, str]:
     """Return the (myst_html, rst_html, rendering_html) tuple for `myst`.
 
     Search the Reference matrix table and return the first row whose first
@@ -681,9 +679,7 @@ def test_reference_matrix_links(built_docs, myst, expected_text, expected_link):
     rendered Rendering column.
     """
     html = read_html(built_docs, "sphinx.html")
-    first_html, rst_html, rendering_html = _extract_reference_table_rows(
-        html, myst
-    )
+    first_html, rst_html, rendering_html = _extract_reference_table_rows(html, myst)
 
     # Ensure the first-column MyST example is wrapped in <span class="pre">...
     m1 = re.search(r'<span class="pre">(.*?)</span>', first_html, re.DOTALL)


### PR DESCRIPTION
### Description

Auto-formats Python files with [autopep8](https://github.com/hhatto/autopep8) (comment wrapping) and [Ruff](https://docs.astral.sh/ruff/) (linting and formatting). When no `[tool.ruff]` section or `ruff.toml` is present, [repomatic's bundled defaults](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/ruff.toml) are applied at runtime. See the [`format-python` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize formatting and linting rules via [`[tool.ruff]`](https://docs.astral.sh/ruff/configuration/) and [`[tool.autopep8]`](https://github.com/hhatto/autopep8#configuration) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`876e421d`](https://github.com/kdeldycke/extra-platforms/commit/876e421d50097f839054238df071df2b1f5d1063) |
| **Job** | [`format-python`](https://github.com/kdeldycke/extra-platforms/blob/876e421d50097f839054238df071df2b1f5d1063/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/extra-platforms/blob/876e421d50097f839054238df071df2b1f5d1063/.github/workflows/autofix.yaml) |
| **Run** | [#715.1](https://github.com/kdeldycke/extra-platforms/actions/runs/24711254164) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.14.0`