### PR TITLE
Bump minor version to `v11.2.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [`11.1.1.dev0` (unreleased)](https://github.com/kdeldycke/extra-platforms/compare/v11.1.0...main)
+## [`11.2.0.dev0` (unreleased)](https://github.com/kdeldycke/extra-platforms/compare/v11.1.0...main)
 
 > [!WARNING]
 > This version is **not released yet** and is under active development.

--- a/citation.cff
+++ b/citation.cff
@@ -1,4 +1,4 @@
-cff-version: 11.1.1.dev0
+cff-version: 11.2.0.dev0
 title: "Extra Platforms"
 message: "If you use this software, please cite it as below."
 type: software
@@ -8,6 +8,6 @@ authors:
     email: kevin@deldycke.com
     orcid: "https://orcid.org/0000-0001-9748-9014"
 doi: 10.5281/zenodo.13341712
-version: 11.1.1.dev0
-date-released: 2026-04-21
+version: 11.2.0.dev0
+date-released: 2026-04-24
 url: "https://github.com/kdeldycke/extra-platforms"

--- a/extra_platforms/__init__.py
+++ b/extra_platforms/__init__.py
@@ -395,7 +395,7 @@ Pytest optional.
 """
 
 
-__version__ = "11.1.1.dev0"
+__version__ = "11.2.0.dev0"
 
 
 def _initialize_group_detection_functions() -> list[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "uv-build>=0.9" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "extra-platforms"
-version = "11.1.1.dev0"
+version = "11.2.0.dev0"
 description = "🔎 Detect architectures, platforms, shells, terminals, CI systems and agents, grouped by family"
 readme = "readme.md"
 keywords = [
@@ -259,7 +259,7 @@ extra-platforms = "extra_platforms.__main__:main"
 [project.urls]
 "Changelog" = "https://github.com/kdeldycke/extra-platforms/blob/main/changelog.md"
 "Documentation" = "https://kdeldycke.github.io/extra-platforms"
-"Download" = "https://github.com/kdeldycke/extra-platforms/releases/tag/v11.1.1.dev0"
+"Download" = "https://github.com/kdeldycke/extra-platforms/releases/tag/v11.2.0.dev0"
 "Funding" = "https://github.com/sponsors/kdeldycke"
 "Homepage" = "https://github.com/kdeldycke/extra-platforms"
 "Issues" = "https://github.com/kdeldycke/extra-platforms/issues"
@@ -392,7 +392,7 @@ run.source = [ "extra_platforms" ]
 report.precision = 2
 
 [tool.bumpversion]
-current_version = "11.1.1.dev0"
+current_version = "11.2.0.dev0"
 allow_dirty = true
 ignore_missing_files = true
 # Parse versions with an optional .devN suffix (PEP 440).

--- a/uv.lock
+++ b/uv.lock
@@ -7,11 +7,11 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-14T08:07:46.936297335Z"
+exclude-newer = "2026-04-17T06:43:19.071753212Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
-repomatic = { timestamp = "2026-04-21T08:07:46.936303887Z", span = "PT0S" }
+repomatic = { timestamp = "2026-04-24T06:43:19.071761898Z", span = "PT0S" }
 
 [[package]]
 name = "accessible-pygments"
@@ -608,7 +608,7 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "11.1.1.dev0"
+version = "11.2.0.dev0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
### Description

Ready to be merged into `main` branch, at the discretion of the maintainers, to bump the minor part of the version number. Version bumps are scheduled daily and also triggered after releases. See the [`bump-version` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowschangelogyaml-jobs) for details.

### To bump version to `v11.2.0`

1. **Click `Ready for review`** button below, to get this PR out of `Draft` mode

2. **Click `Rebase and merge`** button below


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `schedule` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`f8dfc47f`](https://github.com/kdeldycke/extra-platforms/commit/f8dfc47ff47d16b7f3d85f573f2c57baaa9a1dc7) |
| **Job** | [`bump-version`](https://github.com/kdeldycke/extra-platforms/blob/f8dfc47ff47d16b7f3d85f573f2c57baaa9a1dc7/.github/workflows/changelog.yaml) |
| **Workflow** | [`changelog.yaml`](https://github.com/kdeldycke/extra-platforms/blob/f8dfc47ff47d16b7f3d85f573f2c57baaa9a1dc7/.github/workflows/changelog.yaml) |
| **Run** | [#439.1](https://github.com/kdeldycke/extra-platforms/actions/runs/24876164627) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.14.0`