### PR TITLE
Format Markdown

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -115,17 +115,17 @@ $ extra-platforms --json
 
 Each trait section contains:
 
-| Field | Description |
-| ----- | ----------- |
-| {attr}`id <Trait.id>` | Unique trait identifier |
-| {attr}`name <Trait.name>` | Human-readable name |
-| {attr}`icon <Trait.icon>` | Single-glyph icon |
-| {attr}`url <Trait.url>` | Reference URL |
-| {attr}`current <Trait.current>` | Whether this trait matches the current environment |
-| {attr}`aliases <Trait.aliases>` | Alternative IDs for this trait |
-| {attr}`symbol <Trait.symbol_id>` | Uppercase symbol for Python imports (`from extra_platforms import AARCH64`) |
-| {attr}`detection <Trait.detection_func_id>` | Detection function name (`from extra_platforms import is_aarch64`) |
-| {attr}`groups <Trait.groups>` | Groups this trait belongs to |
+| Field                                       | Description                                                                 |
+| ------------------------------------------- | --------------------------------------------------------------------------- |
+| {attr}`id <Trait.id>`                       | Unique trait identifier                                                     |
+| {attr}`name <Trait.name>`                   | Human-readable name                                                         |
+| {attr}`icon <Trait.icon>`                   | Single-glyph icon                                                           |
+| {attr}`url <Trait.url>`                     | Reference URL                                                               |
+| {attr}`current <Trait.current>`             | Whether this trait matches the current environment                          |
+| {attr}`aliases <Trait.aliases>`             | Alternative IDs for this trait                                              |
+| {attr}`symbol <Trait.symbol_id>`            | Uppercase symbol for Python imports (`from extra_platforms import AARCH64`) |
+| {attr}`detection <Trait.detection_func_id>` | Detection function name (`from extra_platforms import is_aarch64`)          |
+| {attr}`groups <Trait.groups>`               | Groups this trait belongs to                                                |
 
 Trait-specific fields (like `machine`, `version`, `codename`) are included when available.
 


### PR DESCRIPTION
### Description

Auto-formats Markdown files with [mdformat](https://github.com/hukkin/mdformat) and its plugins. See the [`format-markdown` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowsautofixyaml-jobs) for details.

> [!TIP]
> Customize Markdown formatting via [`[tool.mdformat]`](https://mdformat.readthedocs.io/en/stable/users/configuration_file.html) in your `pyproject.toml`, or via a native `.mdformat.toml` file.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`b64df8a8`](https://github.com/kdeldycke/extra-platforms/commit/b64df8a8c5a989e007a51087bad54b2f45d6a800) |
| **Job** | [`format-markdown`](https://github.com/kdeldycke/extra-platforms/blob/b64df8a8c5a989e007a51087bad54b2f45d6a800/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/extra-platforms/blob/b64df8a8c5a989e007a51087bad54b2f45d6a800/.github/workflows/autofix.yaml) |
| **Run** | [#740.1](https://github.com/kdeldycke/extra-platforms/actions/runs/24890366902) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.14.0`