### PR TITLE
Bump major version to `v13.0.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [`12.0.4.dev0` (unreleased)](https://github.com/kdeldycke/extra-platforms/compare/v12.0.3...main)
+## [`13.0.0.dev0` (unreleased)](https://github.com/kdeldycke/extra-platforms/compare/v12.0.3...main)
 
 > [!WARNING]
 > This version is **not released yet** and is under active development.

--- a/citation.cff
+++ b/citation.cff
@@ -1,4 +1,4 @@
-cff-version: 12.0.4.dev0
+cff-version: 13.0.0.dev0
 title: "Extra Platforms"
 message: "If you use this software, please cite it as below."
 type: software
@@ -8,6 +8,6 @@ authors:
     email: kevin@deldycke.com
     orcid: "https://orcid.org/0000-0001-9748-9014"
 doi: 10.5281/zenodo.13341712
-version: 12.0.4.dev0
-date-released: 2026-04-28
+version: 13.0.0.dev0
+date-released: 2026-05-25
 url: "https://github.com/kdeldycke/extra-platforms"

--- a/extra_platforms/__init__.py
+++ b/extra_platforms/__init__.py
@@ -399,7 +399,7 @@ Pytest optional.
 """
 
 
-__version__ = "12.0.4.dev0"
+__version__ = "13.0.0.dev0"
 
 
 def _initialize_group_detection_functions() -> list[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "uv-build>=0.9" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "extra-platforms"
-version = "12.0.4.dev0"
+version = "13.0.0.dev0"
 description = "🔎 Detect architectures, platforms, shells, terminals, CI systems and agents, grouped by family"
 readme = "readme.md"
 keywords = [
@@ -261,7 +261,7 @@ extra-platforms = "extra_platforms.__main__:main"
 [project.urls]
 "Changelog" = "https://github.com/kdeldycke/extra-platforms/blob/main/changelog.md"
 "Documentation" = "https://kdeldycke.github.io/extra-platforms"
-"Download" = "https://github.com/kdeldycke/extra-platforms/releases/tag/v12.0.4.dev0"
+"Download" = "https://github.com/kdeldycke/extra-platforms/releases/tag/v13.0.0.dev0"
 "Funding" = "https://github.com/sponsors/kdeldycke"
 "Homepage" = "https://github.com/kdeldycke/extra-platforms"
 "Issues" = "https://github.com/kdeldycke/extra-platforms/issues"
@@ -392,7 +392,7 @@ run.source = [ "extra_platforms" ]
 report.precision = 2
 
 [tool.bumpversion]
-current_version = "12.0.4.dev0"
+current_version = "13.0.0.dev0"
 allow_dirty = true
 ignore_missing_files = true
 # Parse versions with an optional .devN suffix (PEP 440).

--- a/uv.lock
+++ b/uv.lock
@@ -604,7 +604,7 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "12.0.4.dev0"
+version = "13.0.0.dev0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
### Description

Ready to be merged into `main` branch, at the discretion of the maintainers, to bump the major part of the version number. Version bumps are scheduled daily and also triggered after releases. See the [`bump-version` job documentation](https://github.com/kdeldycke/repomatic?tab=readme-ov-file#githubworkflowschangelogyaml-jobs) for details.

### To bump version to `v13.0.0`

1. **Click `Ready for review`** button below, to get this PR out of `Draft` mode

2. **Click `Rebase and merge`** button below


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`60460caa`](https://github.com/kdeldycke/extra-platforms/commit/60460caacbe23f902b9892e317e5e18687ad5128) |
| **Job** | [`bump-version`](https://github.com/kdeldycke/extra-platforms/blob/60460caacbe23f902b9892e317e5e18687ad5128/.github/workflows/changelog.yaml) |
| **Workflow** | [`changelog.yaml`](https://github.com/kdeldycke/extra-platforms/blob/60460caacbe23f902b9892e317e5e18687ad5128/.github/workflows/changelog.yaml) |
| **Run** | [#494.1](https://github.com/kdeldycke/extra-platforms/actions/runs/26396893223) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.14.0`