### PR TITLE
Fix vulnerable dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -314,6 +314,7 @@ dependency-groups.docs = { requires-python = ">= 3.12" }
 # Relative dates are fine here because the Renovate lock-maintenance job
 # (sync-uv-lock) reverts uv.lock when the only diff is timestamp noise.
 exclude-newer = "1 week"
+exclude-newer-package = { idna = "0 day" }
 # Package is at root level, not in "./src/".
 build-backend.module-root = ""
 

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,11 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P1W"
 
+[options.exclude-newer-package]
+gitpython = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+urllib3 = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+idna = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+
 [[package]]
 name = "accessible-pygments"
 version = "0.0.5"
@@ -825,14 +830,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.46"
+version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb", marker = "python_full_version >= '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]
@@ -874,11 +879,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.12"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/12/2948fbe5513d062169bd91f7d7b1cd97bc8894f32946b71fa39f6e63ca0c/idna-3.12.tar.gz", hash = "sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254", size = 194350, upload-time = "2026-04-21T13:32:48.916Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/b2/acc33950394b3becb2b664741a0c0889c7ef9f9ffbfa8d47eddb53a50abd/idna-3.12-py3-none-any.whl", hash = "sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67", size = 68634, upload-time = "2026-04-21T13:32:47.403Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]
@@ -2134,11 +2139,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Upgrades packages with known security vulnerabilities detected by [`uv audit`](https://docs.astral.sh/uv/reference/cli/#uv-audit) against the [Python Packaging Advisory Database](https://github.com/pypa/advisory-database). Uses [`--exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) to bypass the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown for security fixes. See the [`fix-vulnerable-deps` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Vulnerabilities

| Package | Advisory | Current | Fixed | Sources |
| :-- | :-- | :-- | :-- | :-- |
| [gitpython](https://pypi.org/project/gitpython/) | [GHSA-7545-fcxq-7j24](https://nvd.nist.gov/vuln/detail/CVE-2026-44243): GitPython reference APIs has a path traversal vulnerability that allows arbitrary file write and delete outside the repository | `3.1.46` | `3.1.48` | [`github-advisories`](https://github.com/advisories/GHSA-7545-fcxq-7j24), [`uv-audit`](https://nvd.nist.gov/vuln/detail/CVE-2026-44243) |
| [gitpython](https://pypi.org/project/gitpython/) | [GHSA-mv93-w799-cj2w](https://github.com/advisories/GHSA-rpm5-65cw-6hj4): GitPython: Newline injection in config_writer() section parameter bypasses CVE-2026-42215 patch, enabling RCE via core.hooksPath | `3.1.46` | `3.1.50` | [`github-advisories`](https://github.com/advisories/GHSA-mv93-w799-cj2w), [`uv-audit`](https://github.com/advisories/GHSA-rpm5-65cw-6hj4) |
| [gitpython](https://pypi.org/project/gitpython/) | [GHSA-rpm5-65cw-6hj4](https://nvd.nist.gov/vuln/detail/CVE-2026-42215): GitPython has Command Injection via Git options bypass | `3.1.46` | `3.1.47` | [`github-advisories`](https://github.com/advisories/GHSA-rpm5-65cw-6hj4), [`uv-audit`](https://nvd.nist.gov/vuln/detail/CVE-2026-42215) |
| [gitpython](https://pypi.org/project/gitpython/) | [GHSA-v87r-6q3f-2j67](https://nvd.nist.gov/vuln/detail/CVE-2026-44244): GitPython: Newline injection in config_writer().set_value() enables RCE via core.hooksPath | `3.1.46` | `3.1.49` | [`github-advisories`](https://github.com/advisories/GHSA-v87r-6q3f-2j67), [`uv-audit`](https://nvd.nist.gov/vuln/detail/CVE-2026-44244) |
| [gitpython](https://pypi.org/project/gitpython/) | [GHSA-x2qx-6953-8485](https://nvd.nist.gov/vuln/detail/CVE-2026-42284): GitPython: Unsafe option check validates multi_options before shlex.split transformation | `3.1.46` | `3.1.47` | [`github-advisories`](https://github.com/advisories/GHSA-x2qx-6953-8485), [`uv-audit`](https://nvd.nist.gov/vuln/detail/CVE-2026-42284) |
| [idna](https://pypi.org/project/idna/) | [GHSA-65pc-fj4g-8rjx](https://github.com/kjd/idna/security/advisories/GHSA-65pc-fj4g-8rjx): Internationalized Domain Names in Applications (IDNA): Specially crafted inputs to idna.encode() can bypass CVE-2024-3651 fix | `3.12` | `3.15` | [`github-advisories`](https://github.com/advisories/GHSA-65pc-fj4g-8rjx), [`uv-audit`](https://github.com/kjd/idna/security/advisories/GHSA-65pc-fj4g-8rjx) |
| [urllib3](https://pypi.org/project/urllib3/) | [GHSA-mf9v-mfxr-j63j](https://nvd.nist.gov/vuln/detail/CVE-2026-44432): urllib3: Decompression-bomb safeguards bypassed in parts of the streaming API | `2.6.3` | `2.7.0` | [`github-advisories`](https://github.com/advisories/GHSA-mf9v-mfxr-j63j), [`uv-audit`](https://nvd.nist.gov/vuln/detail/CVE-2026-44432) |
| [urllib3](https://pypi.org/project/urllib3/) | [GHSA-qccp-gfcp-xxvc](https://nvd.nist.gov/vuln/detail/CVE-2026-44431): urllib3: Sensitive headers forwarded across origins in proxied low-level redirects | `2.6.3` | `2.7.0` | [`github-advisories`](https://github.com/advisories/GHSA-qccp-gfcp-xxvc), [`uv-audit`](https://nvd.nist.gov/vuln/detail/CVE-2026-44431) |
| [urllib3](https://pypi.org/project/urllib3/) | [PYSEC-2026-141](https://github.com/urllib3/urllib3/security/advisories/GHSA-qccp-gfcp-xxvc): No summary provided | `2.6.3` | `2.7.0` | [`uv-audit`](https://github.com/urllib3/urllib3/security/advisories/GHSA-qccp-gfcp-xxvc) |
| [urllib3](https://pypi.org/project/urllib3/) | [PYSEC-2026-142](https://github.com/urllib3/urllib3/security/advisories/GHSA-mf9v-mfxr-j63j): No summary provided | `2.6.3` | `2.7.0` | [`uv-audit`](https://github.com/urllib3/urllib3/security/advisories/GHSA-mf9v-mfxr-j63j) |

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-05-18`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [gitpython](https://pypi.org/project/gitpython/) | `3.1.46` → `3.1.50` | 2026-05-06 |
| [idna](https://pypi.org/project/idna/) | `3.12` → `3.16` | 2026-05-22 |
| [urllib3](https://pypi.org/project/urllib3/) | `2.6.3` → `2.7.0` | 2026-05-07 |

### Release notes

<details>
<summary><code>gitpython</code></summary>

#### [`3.1.47`](https://github.com/gitpython-developers/GitPython/releases/tag/3.1.47)

## Advisories

* https://redirect.github.com/gitpython-developers/GitPython/security/advisories/GHSA-rpm5-65cw-6hj4
* https://redirect.github.com/gitpython-developers/GitPython/security/advisories/GHSA-x2qx-6953-8485

## What's Changed
* Prepare next release by @​Byron in https://redirect.github.com/gitpython-developers/GitPython/pull/2095
* Bump git/ext/gitdb from `335c0f6` to `4c63ee6` by @​dependabot[bot] in https://redirect.github.com/gitpython-developers/GitPython/pull/2096
* DOC: README Add urls and updated a relative url by @​Timour-Ilyas in https://redirect.github.com/gitpython-developers/GitPython/pull/2098
* Fix GitConfigParser ignoring multiple [include] path entries by @​daniel7an in https://redirect.github.com/gitpython-developers/GitPython/pull/2100
* Switch back from Alpine to Debian for WSL by @​EliahKagan in https://redirect.github.com/gitpython-developers/GitPython/pull/2108
* Bump git/ext/gitdb from `4c63ee6` to `5c1b303` by @​dependabot[bot] in https://redirect.github.com/gitpython-developers/GitPython/pull/2106
* Run `gc.collect()` twice in `test_rename` on Python 3.12 by @​EliahKagan in https://redirect.github.com/gitpython-developers/GitPython/pull/2109
* fix: guard AutoInterrupt terminate during interpreter shutdown by @​lweyrich1 in https://redirect.github.com/gitpython-developers/GitPython/pull/2105
* Improve CI infrastructure for pre-commit by @​EliahKagan in https://redirect.github.com/gitpython-developers/GitPython/pull/2110
* Bump the pre-commit group with 5 updates by @​dependabot[bot] in https://redirect.github.com/gitpython-developers/GitPython/pull/2111
* Upgrade Sphinx for 3.14 support; drop doc build support on 3.8; test 3.14 by @​EliahKagan in https://redirect.github.com/gitpython-developers/GitPython/pull/2112
* Fix `Repo.active_branch` resolution for reftable-backed repositories by @​Copilot in https://redirect.github.com/gitpython-developers/GitPython/pull/2114

... [Full release notes](https://github.com/gitpython-developers/GitPython/releases/tag/3.1.47)

#### [`3.1.48`](https://github.com/gitpython-developers/GitPython/releases/tag/3.1.48)

Accidentally deleted the previous GH release, it did mention the advisory this fixes.

## What's Changed
* prevent out-of-repo access when manipulating references. by @​Byron in https://redirect.github.com/gitpython-developers/GitPython/pull/2134


**Full Changelog**: https://redirect.github.com/gitpython-developers/GitPython/compare/3.1.47...3.1.48

#### [`3.1.49`](https://github.com/gitpython-developers/GitPython/releases/tag/3.1.49)

## What's Changed
* reject control chars in written values in configuration by @​Byron in https://redirect.github.com/gitpython-developers/GitPython/pull/2137
* Improve pure Python rev-parse coverage and behavior  by @​Copilot in https://redirect.github.com/gitpython-developers/GitPython/pull/2136


**Full Changelog**: https://redirect.github.com/gitpython-developers/GitPython/compare/3.1.48...3.1.49

#### [`3.1.50`](https://github.com/gitpython-developers/GitPython/releases/tag/3.1.50)

## What's Changed
* Bump https://redirect.github.com/astral-sh/ruff-pre-commit from v0.15.8 to 0.15.12 in the pre-commit group by @​dependabot[bot] in https://redirect.github.com/gitpython-developers/GitPython/pull/2140
* Bump git/ext/gitdb from `335c0f6` to `53c94d6` by @​dependabot[bot] in https://redirect.github.com/gitpython-developers/GitPython/pull/2141
* Fix Repo() autodiscovery in linked worktrees when GIT_DIR is set by @​meliezer in https://redirect.github.com/gitpython-developers/GitPython/pull/2128
* Validate config key names before writing by @​Byron in https://redirect.github.com/gitpython-developers/GitPython/pull/2142

## New Contributors
* @​meliezer made their first contribution in https://redirect.github.com/gitpython-developers/GitPython/pull/2128

**Full Changelog**: https://redirect.github.com/gitpython-developers/GitPython/compare/3.1.49...3.1.50

</details>

<details>
<summary><code>idna</code></summary>

[Changelog](https://redirect.github.com/kjd/idna/blob/master/HISTORY.md)

</details>

<details>
<summary><code>urllib3</code></summary>

#### [`2.7.0`](https://github.com/urllib3/urllib3/releases/tag/2.7.0)

## 🚀 urllib3 is fundraising for HTTP/2 support

[urllib3 is raising ~$40,000 USD](https://sethmlarson.dev/urllib3-is-fundraising-for-http2-support) to release HTTP/2 support and ensure long-term sustainable maintenance of the project after a sharp decline in financial support. If your company or organization uses Python and would benefit from HTTP/2 support in Requests, pip, cloud SDKs, and thousands of other projects [please consider contributing financially](https://opencollective.com/urllib3) to ensure HTTP/2 support is developed sustainably and maintained for the long-haul.

Thank you for your support.

## Security

Addressed high-severity security issues. Impact was limited to specific use cases detailed in the accompanying advisories; overall user exposure was estimated to be marginal.

- Decompression-bomb safeguards of the streaming API were bypassed:

  1. When `HTTPResponse.drain_conn()` was called after the response had been read and decompressed partially. (Reported by @​Cycloctane)
  2. During the second `HTTPResponse.read(amt=N)` or `HTTPResponse.stream(amt=N)` call when the response was decompressed using the official [Brotli](https://pypi.org/project/brotli/) library. (Reported by @​kimkou2024)

  See GHSA-mf9v-mfxr-j63j for details.

- HTTP pools created using `ProxyManager.connection_from_url` did not strip sensitive headers specified in `Retry.remove_headers_on_redirect` when redirecting to a different host. (GHSA-qccp-gfcp-xxvc reported by @​christos-spearbit)

## Deprecations and Removals

- Used `FutureWarning` instead of `DeprecationWarning` for better visibility of existing deprecation notices. Rescheduled the removal of deprecated features to version 3.0. (https://redirect.github.com/urllib3/urllib3/issues/3763)
- Removed support for end-of-life Python 3.9. (https://redirect.github.com/urllib3/urllib3/issues/3720)
- Removed support for end-of-life PyPy3.10. (https://redirect.github.com/urllib3/urllib3/issues/4979)

... [Full release notes](https://github.com/urllib3/urllib3/releases/tag/2.7.0)

</details>


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`eccf98a4`](https://github.com/kdeldycke/extra-platforms/commit/eccf98a4e97b829f7c1f72eee772891a27cef00d) |
| **Job** | [`fix-vulnerable-deps`](https://github.com/kdeldycke/extra-platforms/blob/eccf98a4e97b829f7c1f72eee772891a27cef00d/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/extra-platforms/blob/eccf98a4e97b829f7c1f72eee772891a27cef00d/.github/workflows/autofix.yaml) |
| **Run** | [#759.1](https://github.com/kdeldycke/extra-platforms/actions/runs/26398012511) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.20.0`