### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1902,14 +1902,14 @@ wheels = [
 
 [[package]]
 name = "sphinx-autodoc-typehints"
-version = "3.10.5"
+version = "3.10.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx", marker = "python_full_version >= '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/88/f4698f838b8cc030f3df73cf529f96d7c9e6dd3e3ff40968b7fe4d86c748/sphinx_autodoc_typehints-3.10.5.tar.gz", hash = "sha256:a54dfab95a6b5e8601543d25474497e98ed59268ac0ab01b3daba9817cf9707e", size = 79721, upload-time = "2026-06-03T15:30:28.181Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/2a/791d884ccd04b70ae4e634e526e16744a8ccf6d2ba1b83ac910e57cbbe84/sphinx_autodoc_typehints-3.10.6.tar.gz", hash = "sha256:fc637a286a62dd53a3dbbd6bc3831cf6034e3b4abee0299c84a53982f2bf1e0d", size = 80926, upload-time = "2026-06-11T14:52:51.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/9a/98ba24ca28b4a4afbb5066805838c7e1149b8de1e6f5e02774e0f39f13db/sphinx_autodoc_typehints-3.10.5-py3-none-any.whl", hash = "sha256:7155748080735731c892d09b5128bc4e5303795691ca8515ccf333b1efd8d964", size = 40433, upload-time = "2026-06-03T15:30:26.892Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/81/1fbaf1e78737358c2d7ccf74f6bbcb65309f946ae91e5b1ff946c75679d0/sphinx_autodoc_typehints-3.10.6-py3-none-any.whl", hash = "sha256:d960db7426438f4f3d28aa66c7f1efd6ac32708cc95814e4a9c5538691f410c8", size = 40742, upload-time = "2026-06-11T14:52:50.627Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-06-11`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | [`3.10.5` → `3.10.6`](https://github.com/tox-dev/sphinx-autodoc-typehints/compare/3.10.5...3.10.6) | 2026-06-11 |

### Release notes

<details>
<summary><code>sphinx-autodoc-typehints</code></summary>

#### [`3.10.6`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.10.6)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* 🐛 fix(docstring): keep types on params with a trailing underscore by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/714
* ♻️ refactor(tests): fold per-issue test files into topical ones by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/715
* 🐛 fix(resolver): survive PEP 649 lazy annotation evaluation errors by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/713


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.10.5...3.10.6

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`65b7a751`](https://github.com/kdeldycke/extra-platforms/commit/65b7a751fb090403ab3926fd994af073955a86c5) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/extra-platforms/blob/65b7a751fb090403ab3926fd994af073955a86c5/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/extra-platforms/blob/65b7a751fb090403ab3926fd994af073955a86c5/.github/workflows/autofix.yaml) |
| **Run** | [#789.1](https://github.com/kdeldycke/extra-platforms/actions/runs/27767863595) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.27.0`