### PR TITLE
Sync action pins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -45,7 +45,7 @@ jobs:
     outputs:
       metadata: ${{ steps.metadata.outputs.metadata }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7.5.0
       - name: Run repomatic metadata
         id: metadata
@@ -70,7 +70,7 @@ jobs:
     # We keep going when a job flagged as not stable fails.
     continue-on-error: ${{ matrix.state == 'unstable' }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7.5.0
       - name: Force native ARM64 Python on Windows ARM64
         # Workaround for https://github.com/astral-sh/uv/issues/12906: uv defaults to x86_64 Python on ARM64 Windows,


### PR DESCRIPTION
### Description

Bumps SHA-pinned GitHub Actions (`uses: owner/repo@<sha> # vX.Y.Z`) to their latest releases that have cleared the stabilization cooldown, resolving each release tag to its commit SHA. See the [`sync-action-pins` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated actions

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-06-29` are held back.

| Action | Change | Released |
| :-- | :-- | :-- |
| [actions/checkout](https://github.com/actions/checkout) | [`v6.0.2` → `v7.0.0`](https://github.com/actions/checkout/compare/v6.0.2...v7.0.0) | 2026-06-18 (a month ago) |

### Release notes

<details>
<summary><code>actions/checkout</code></summary>

#### [`v6.0.3`](https://github.com/actions/checkout/releases/tag/v6.0.3)

## What's Changed
* Update changelog by @​ericsciple in https://redirect.github.com/actions/checkout/pull/2357
* fix: expand merge commit SHA regex and add SHA-256 test cases by @​yaananth in https://redirect.github.com/actions/checkout/pull/2414
* Fix checkout init for SHA-256 repositories by @​yaananth in https://redirect.github.com/actions/checkout/pull/2439
* Update changelog for v6.0.3 by @​yaananth in https://redirect.github.com/actions/checkout/pull/2446

## New Contributors
* @​yaananth made their first contribution in https://redirect.github.com/actions/checkout/pull/2414

**Full Changelog**: https://redirect.github.com/actions/checkout/compare/v6...v6.0.3

#### [`v7.0.0`](https://github.com/actions/checkout/releases/tag/v7.0.0)

## What's Changed
* block checking out fork pr for pull_request_target and workflow_run by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2454
* Bump actions/publish-immutable-action from 0.0.3 to 0.0.4 in the minor-actions-dependencies group across 1 directory by @​dependabot[bot] in https://redirect.github.com/actions/checkout/pull/2458
* Bump flatted from 3.3.1 to 3.4.2 by @​dependabot[bot] in https://redirect.github.com/actions/checkout/pull/2460
* Bump js-yaml from 4.1.0 to 4.2.0 by @​dependabot[bot] in https://redirect.github.com/actions/checkout/pull/2461
* Bump @​actions/core and @​actions/tool-cache and Remove uuid by @​dependabot[bot] in https://redirect.github.com/actions/checkout/pull/2459
* upgrade module to esm and update dependencies by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2463
* Bump the minor-npm-dependencies group across 1 directory with 3 updates by @​dependabot[bot] in https://redirect.github.com/actions/checkout/pull/2462
* getting ready for checkout v7 release by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2464
* update error wording by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2467

## New Contributors
* @​aiqiaoy made their first contribution in https://redirect.github.com/actions/checkout/pull/2454

**Full Changelog**: https://redirect.github.com/actions/checkout/compare/v6.0.3...v7.0.0

</details>

### 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window. Each becomes adoptable on its eligible date.

| Action | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [astral-sh/setup-uv](https://github.com/astral-sh/setup-uv) | `8.2.0` | `8.3.1` | 2026-07-07 (just now) | 2026-07-15 (in a week) |

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`action-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#action-pins-sync)
- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`71125fc4`](https://github.com/kdeldycke/extra-platforms/commit/71125fc46441e756bc0ab13cdfe997291f4fc3a3) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/extra-platforms/blob/71125fc46441e756bc0ab13cdfe997291f4fc3a3/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/extra-platforms/blob/71125fc46441e756bc0ab13cdfe997291f4fc3a3/.github/workflows/autofix.yaml) |
| **Run** | [#796.1](https://github.com/kdeldycke/extra-platforms/actions/runs/28896473288) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.0.0`