### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Run repomatic metadata
         id: metadata
         run: >
-          uvx --no-progress 'repomatic==6.14.0' metadata
+          uvx --no-progress 'repomatic==6.31.0' metadata
           --format github-json --output "$GITHUB_OUTPUT"
           test_matrix test_matrix_pr
 


### PR DESCRIPTION
### Description

Bumps npm and PyPI version literals embedded in workflow YAML (`npm install pkg@x`, `uvx '<pkg>==x'`) to their latest releases that have cleared the stabilization cooldown. See the [`sync-workflow-pins` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-06-29` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [repomatic](https://pypi.org/project/repomatic/) | `6.14.0` → `6.31.0` | 2026-06-27 (a week ago) |

### Release notes

<details>
<summary><code>repomatic</code></summary>

#### [`v6.15.0`](https://github.com/kdeldycke/repomatic/releases/tag/v6.15.0)

> [!NOTE]
> `6.15.0` is available on [🐍 PyPI](https://pypi.org/project/repomatic/6.15.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v6.15.0).

- Set `validate = false` in the bundled `mdformat.toml` so `mdformat-recover-urls` decodes percent-encoded non-ASCII characters in link destinations back to their original form. Without this, anchor links with Chinese, accented, or other non-ASCII characters got rewritten to `%XX` sequences on every `format-markdown` run.
- Add 💸/🆓 licensing markers to the awesome-list contributing guide, issue template, and PR template (English and Chinese mirrors). Tool, dataset, and project entries are now flagged with 💸 (commercial vendor selling a paid version on top of the OSS core) or 🆓 (fully open-source: foundation-governed, community-driven, corporate-OSS without a paid product, or support-only commercial model). Articles, papers, blog posts, news items, and curation lists remain unmarked. The two markers are mutually exclusive and the awesome-list entry format keeps `awesome-lint`-compatible ` - ` syntax.
- Detect vulnerable dependencies from the GitHub Advisory Database in addition to the PyPA Advisory Database. The `fix-vulnerable-deps` job now unions `uv audit` and the repository's Dependabot alerts feed, deduplicates by `(package, advisory_id)`, credits each entry's source(s) in the PR body, and shows the `exclude-newer` cooldown cutoff above the updated packages table so reviewers can confirm which upgrades required a cooldown bypass. Configurable via `[tool.repomatic] vulnerable-deps.sources`.

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.15.0)

#### [`v6.16.0`](https://github.com/kdeldycke/repomatic/releases/tag/v6.16.0)

> [!NOTE]
> `6.16.0` is available on [🐍 PyPI](https://pypi.org/project/repomatic/6.16.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v6.16.0).

- Add `sphinx-docs` agent to the `agents` component (deployed by `repomatic init agents` alongside `grunt-qa` and `qa-engineer`, or via `[tool.repomatic] include = ["agents"]`). The agent carries a canonical Sphinx extension set with notes on `sphinx_click` vs `click_extra.sphinx`, a standard octicon registry, governance rules for `suppress_warnings`/`nitpick_ignore`/`linkcheck_ignore` entries, the `<!-- {feature}-{kind}-start -->` auto-region marker convention, and a Sphinx cross-reference render test recipe. Drops `sphinx_issues` from the set: its `:issue:`/`:pr:`/`:user:`/`:commit:` roles render only inside Sphinx, appearing as raw role text in GitHub's repo browser, IDE previews, and PyPI descriptions; a Python migration script (covering MyST roles, reST roles, and cross-repo prefixed forms) and a matching `sphinx-docs-sync` audit category are included. `docs/myst-docstrings.md` documents the load-order failure mode (backtick-doubled `:py:obj:` roles) when `repomatic.myst_docstrings` loads after `sphinx_autodoc_typehints`.
- Add three `[tool.repomatic.workflow]` configuration knobs for customizing `paths:` filters in generated thin callers and synced headers: `extra-paths` appends repo-specific entries (like `install.sh`, `dotfiles/**`) to every workflow's filter, `ignore-paths` strips canonical entries that don't exist downstream (like `tests/**`, `uv.lock`) by exact match, and `paths` keyed by workflow filename replaces a workflow's filter wholesale (skipping the other knobs and `--source-paths` for that filename).

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.16.0)

#### [`v6.17.0`](https://github.com/kdeldycke/repomatic/releases/tag/v6.17.0)

> [!NOTE]
> `6.17.0` is available on [🐍 PyPI](https://pypi.org/project/repomatic/6.17.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v6.17.0).

- Fix parallel `OSError: Lock for file .git/config did already exist` test failures. `tests/test_git_ops.py` and `tests/test_metadata.py` share `pytestmark = pytest.mark.xdist_group("git")` so pydriller's `Git(".")` initialization (which acquires `.git/config.lock` on every call) is serialized to a single pytest-xdist worker. Add `mypy_path = "docs"` to `[tool.mypy]` so mypy resolves `import docs_update` in `tests/test_readme.py` against `docs/docs_update.py`.
- Fix backslash-escaped brackets rendering literally in `docs/configuration.md` per-option `**Type:**` lines (like `list\[dict[str, str]\]`). The escape, needed only for raw GFM table cells in the `repomatic show-config` CLI output (where `mdformat` would otherwise interpret `[…]` as a markdown link), was leaking into inline-code spans where backslashes are literal in CommonMark. `_format_type` now returns clean Python type strings; the new `escape_type_for_gfm_table` helper is applied only at the CLI rendering layer.
- Add `--template-file <path>` and `--template-arg KEY=VALUE` flags to `repomatic pr-body` so downstream repos can render project-specific PR templates without forking repomatic. `--template` and `--template-file` are mutually exclusive. `load_template`, `render_template`, `render_title`, `render_commit_message`, and `template_args` now accept a {class}`~pathlib.Path` to read a template from disk in addition to a packaged-resource name. `render_title` returns an empty string instead of raising `KeyError` when the frontmatter defines no `title`.

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.17.0)

#### [`v6.18.1`](https://github.com/kdeldycke/repomatic/releases/tag/v6.18.1)

> [!NOTE]
> `6.18.1` is available on [🐍 PyPI](https://pypi.org/project/repomatic/6.18.1/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v6.18.1).

- Fix `publish-pypi` composite action attempting to verify build attestations on every file in the workflow workspace (including `changelog.md`, `pyproject.toml`, etc.) instead of just the downloaded distribution artifacts. The `actions/download-artifact` step now downloads to `dist/` so the verification loop and `uv publish` only target the actual artifact files.

**Full changelog**: [`v6.18.0...v6.18.1`](https://redirect.github.com/kdeldycke/repomatic/compare/v6.18.0...v6.18.1)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`repomatic-6.18.1-linux-arm64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.18.1/repomatic-6.18.1-linux-arm64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/640fd73bf0c0c6c26b78411d63cb3deeb8a8d25d219b6904019755e7f1c18813) |
| [`repomatic-6.18.1-linux-x64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.18.1/repomatic-6.18.1-linux-x64.bin) | 0 / 63 | [View scan](https://www.virustotal.com/gui/file/5272a621c9779cbc4405fd108fce397182152bd270dd8bca6061004e8413e4b2) |
| [`repomatic-6.18.1-macos-arm64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.18.1/repomatic-6.18.1-macos-arm64.bin) | 4 / 62 | [View scan](https://www.virustotal.com/gui/file/6307fa0c9a7504d841b82ba49036a90107d9959d692dd938b6aff3efc79f71f4) |
| [`repomatic-6.18.1-macos-x64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.18.1/repomatic-6.18.1-macos-x64.bin) | 1 / 61 | [View scan](https://www.virustotal.com/gui/file/e7880203465bf31294ba2c476481b2cc6261442cbacdda702b2d807821e2231e) |

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.18.1)

#### [`v6.18.2`](https://github.com/kdeldycke/repomatic/releases/tag/v6.18.2)

> [!NOTE]
> `6.18.2` is available on [🐍 PyPI](https://pypi.org/project/repomatic/6.18.2/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v6.18.2).

- Fix `release.yaml` uploading distributions to PyPI without PEP 740 attestations. The build job now signs each dist file with `pypi-attestations sign` (using the job's OIDC token via Sigstore), writing `<dist>.publish.attestation` sidecars directly into `./dist/` so the dist artifact carries its own attestations. The `publish-pypi` composite action shrinks to setup-uv → download artifact → `uv publish dist/*`. Replaces the previous `actions/attest` + GitHub-attestation-API flow for Python distributions: the Nuitka binary attestation flow is unchanged, and PyPI's PEP 740 provenance is now populated so the `setup-guide` `check_pypi_trusted_publisher` probe can confirm the trusted publisher is wired up. Removes the `attestation-signer-repo` input from the composite action and the separate `attestation-<artifact-name>` artifact: dist files and their `.publish.attestation` sidecars travel together in a single artifact and end up alongside each other on the GitHub release page.

**Full changelog**: [`v6.18.1...v6.18.2`](https://redirect.github.com/kdeldycke/repomatic/compare/v6.18.1...v6.18.2)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`repomatic-6.18.2-linux-arm64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.18.2/repomatic-6.18.2-linux-arm64.bin) | 0 / 62 | [View scan](https://www.virustotal.com/gui/file/2ad16bf0873fb112f61ba285138400470f78a3bad8dbd203b66c2f1e81e9869d) |
| [`repomatic-6.18.2-linux-x64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.18.2/repomatic-6.18.2-linux-x64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/028e2f9059e3417e59b17a65006e5f3c92855cd7bc57188dcbb8718cd2dcfe3a) |

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.18.2)

#### [`v6.18.3`](https://github.com/kdeldycke/repomatic/releases/tag/v6.18.3)

> [!NOTE]
> `6.18.3` is available on [🐍 PyPI](https://pypi.org/project/repomatic/6.18.3/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v6.18.3).

- Fix `autofix.yaml` `setup-guide` job being skipped on `workflow_dispatch` re-runs. The `if:` condition now allows both `push` and `workflow_dispatch` events instead of `push` only, so manual re-runs from the Actions UI re-evaluate the setup guide and update the issue accordingly.
- Fix `release.yaml` `publish-pypi` job running against downstream callers and failing PyPI trusted publishing with a `job_workflow_ref` mismatch. The gate now uses `github.repository == 'kdeldycke/repomatic'` (which reflects the caller's repo under `workflow_call`) instead of `github.event_name == 'push'` (which stays `push` in both self-release and downstream contexts), so the upstream-only job is properly skipped when invoked from a downstream caller. Downstream repos publish through their own thin-caller `publish-pypi` job, which inherits the correct OIDC context.
- Switch the `compile-binaries` job from `--onefile` to `--mode=onefile`, the documented spelling since Nuitka 4.0 (`--onefile` is now hidden but still accepted).

**Full changelog**: [`v6.18.2...v6.18.3`](https://redirect.github.com/kdeldycke/repomatic/compare/v6.18.2...v6.18.3)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`repomatic-6.18.3-linux-arm64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.18.3/repomatic-6.18.3-linux-arm64.bin) | 0 / 62 | [View scan](https://www.virustotal.com/gui/file/8fd43675d0200cab10c55b1dbd33aa36448a110a3e394f8c33c094d1e3574413) |
| [`repomatic-6.18.3-linux-x64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.18.3/repomatic-6.18.3-linux-x64.bin) | 0 / 64 | [View scan](https://www.virustotal.com/gui/file/e1e0e17a072e75981e3e8dab8accee4ff3c2bdd18cb54e0113ad513da5e1282c) |

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.18.3)

#### [`v6.18.4`](https://github.com/kdeldycke/repomatic/releases/tag/v6.18.4)

> [!NOTE]
> `6.18.4` is available on [🐍 PyPI](https://pypi.org/project/repomatic/6.18.4/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v6.18.4).

- Replace the `RepoScope.NON_AWESOME` variant with `PYTHON_ONLY`, gating affected components on the presence of a PEP 621 `[project].name` in `pyproject.toml` (detected via the new `repomatic.pyproject.is_python_project` helper). Repos that carry `pyproject.toml` only for `[tool.*]` configuration (like dotfiles) are now classified as non-Python and skip Python-flavored components by default. `RepoScope.matches()` now takes both `is_awesome` and `is_python` traits. Existing entries are reclassified: `codecov`, `publish-pypi-action`, `changelog.yaml`, `debug.yaml`, `release.yaml`, and the generated `changelog.md` move to `PYTHON_ONLY`; `renovate` moves to `ALL` (Renovate is language-agnostic). Explicit CLI naming and `[tool.repomatic] include` continue to bypass scope, so a dotfiles repo can still opt into `publish-pypi-action` if needed.
- Extend `release_prep.freeze_workflow_urls` and `unfreeze_workflow_urls` to walk non-symlink YAML files under `repomatic/data/` in addition to `.github/workflows/`. The bundled `release-publish-pypi-job.yaml` fragment now participates in the `@main` ↔ `@vX.Y.Z` rewrite, so wheels built from a freeze commit ship with the pinned action ref baked in. Symlinks in the data dir are skipped to avoid double-processing. `repomatic.github.workflow_sync._PUBLISH_PYPI_DEFAULT_ACTION_REF` is now derived from `DEFAULT_VERSION` so the search string always matches the ref in the (possibly frozen) bundled fragment.
- Bump Biome from `2.4.13` to `2.4.14` and Lychee from `0.24.1` to `0.24.2` in the tool registry.

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.18.4)

#### [`v6.19.0`](https://github.com/kdeldycke/repomatic/releases/tag/v6.19.0)

> [!NOTE]
> `6.19.0` is available on [🐍 PyPI](https://pypi.org/project/repomatic/6.19.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v6.19.0).

- Fix a flaky `.git/config.lock` conflict on `ubuntu-24.04-arm / py3.14t`: `test_skip_binary_build_property_is_bool` in `test_binary.py` accesses `Metadata.skip_binary_build` which, in a CI push event, triggers `Metadata.git` → `pydriller.Git(".")` on a separate xdist worker. The cross-worker lock race caused an `OSError` when the git-group worker ran `test_is_version_bump_allowed_current_repo` simultaneously. Adding `@pytest.mark.xdist_group("git")` to that test serializes it onto the same worker as the other git-touching tests.
- Reconcile orphan version-bump PRs created by races between the `changelog.yaml` schedule and a competing push. The `bump-version` matrix job now always checks out the repo and runs `setup-uv`, and adds a new `Close stale ${{ matrix.part }} bump PR` step that runs when `${part}_bump_allowed` is `false`. The step invokes the new `repomatic close-stale-bump-pr --part minor|major` CLI command, which re-evaluates `is_version_bump_allowed` and closes any open PR on the matching `${part}-version-increment` branch (deleting the branch). Previously the gated steps silently skipped, leaving an orphan PR whose only diff against `main` was `uv.lock` churn from `uv lock --upgrade`. The new step is idempotent: a no-op when no open PR exists on the branch.
- Expand sponsor benefits in the awesome template's `contributing.md`: sponsors now get a dedicated entry in the matching section (visible to readers and LLMs scanning the list body, not only the header banner) and a waiver on the licensing-marker requirement. Add a cross-reference note in the licensing-markers section and explicit heading anchors to support the links in both the English and Chinese variants.

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.19.0)

#### [`v6.20.0`](https://github.com/kdeldycke/repomatic/releases/tag/v6.20.0)

> [!NOTE]
> `6.20.0` is available on [🐍 PyPI](https://pypi.org/project/repomatic/6.20.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v6.20.0).

- **Breaking:** remove `[tool.repomatic] nuitka.extra-args`. Configure Nuitka flags through `[tool.nuitka]` in `pyproject.toml` instead: `--include-data-files=SRC=DEST` becomes `include-data-files = ["SRC=DEST"]`.
- Integrate Nuitka with the tool runner: `repomatic run nuitka` installs the pinned Nuitka, reads `[tool.nuitka]` from `pyproject.toml`, and passes the section as CLI flags (a `true` value becomes a bare `--flag`, a string or number becomes `--key=value`, a list repeats the flag per item). Nuitka now appears in `repomatic run --list` and the tool-runner docs. Add binary metadata to repomatic's `[tool.nuitka]`: `product-name`, `file-description`, `copyright`, native per-OS icons (`icon.png`, `icon.icns`, `icon.ico`), `include-package-data = ["click_extra"]`, and numeric `file-version`/`product-version` kept in sync via a dedicated `[tool.bumpversion]` rule. Build Nuitka binaries on Python 3.14.
- Switch `[tool.typos]` sync mode from `BOOTSTRAP` to `ONGOING`: canonical proper-noun identifiers (`GitHub`, `macOS`, `PyPI`, and the rest) are now merged into any pre-existing `[tool.typos]` section instead of skipping it. Local-only keys, extra `extend-identifiers`, `extend-words`, `extend-exclude`, and `[[files]]` entries survive the merge.
- Add two `[[tool.bumpversion.files]]` rules to the bundled template so downstream Python repos receive them: the `[project]` version search is anchored to `(?m)^version = ` to avoid rewriting `[tool.nuitka]`'s `file-version`/`product-version` keys, and a dedicated rule syncs those numeric keys with `ignore_missing_version = true` (a no-op in repos without `[tool.nuitka]`). Repos carrying the old unanchored `[project]` entry converge on the anchored form without duplication.

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.20.0)

#### [`v6.21.0`](https://github.com/kdeldycke/repomatic/releases/tag/v6.21.0)

> [!NOTE]
> `6.21.0` is available on [🐍 PyPI](https://pypi.org/project/repomatic/6.21.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v6.21.0).

- Replace the `repomatic-release` skill with `repomatic-ship`, a release orchestrator: it reconciles the changelog, code, and docs to the net release state, then commits, pushes, and babysits CI (delegating to `babysit-ci`) until the release PR is ready to rebase-and-merge. Review-gated in normal use, fully autonomous under `--dangerously-skip-permissions`. It does not run the `release-prep` CLI itself (CI's `prepare-release` job does); the version read is advisory and never merges a bump PR.
- Add a `modernize` mode to the `repomatic-deps` skill: it reads the changelogs of dependencies upgraded since the last release and autonomously refactors code to adopt their new features (dropping workarounds, replacing hand-rolled logic, migrating off deprecations), gating each change on the local test suite.
- Extend the `babysit-ci` skill to also monitor and triage the Nuitka `compile-binaries` job in `release.yaml`, catching binary-build breakage before a release reaches the immutable-release wall.
- Decouple the downstream caller's `publish-pypi` job from the reusable workflow's overall result. The job now runs under `always()` and gates on a new `package_built` workflow output (`"true"` when the `build-package` job succeeded) instead of the run's success, so a wheel that built cleanly still publishes to PyPI even when an unrelated job (like a binary test) fails the run.
- Remove the `repomatic-sync`, `repomatic-lint`, and `repomatic-test` skills. Each only wrapped a CLI command that CI already runs on every push, duplicating the mechanical layer.

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.21.0)

#### [`v6.22.0`](https://github.com/kdeldycke/repomatic/releases/tag/v6.22.0)

> [!NOTE]
> `6.22.0` is available on [🐍 PyPI](https://pypi.org/project/repomatic/6.22.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v6.22.0).

- `repomatic init` now prunes downstream orphans of skills, agents, and workflows that repomatic has renamed or removed, so an upstream change (a skill rename like `repomatic-release` becoming `repomatic-ship`, or the `label-sponsors` and `labeller-*` workflows being merged into `labels.yaml`) propagates automatically instead of leaving a stale file behind. A skill or agent copy is deleted when its content matches any version repomatic shipped; a workflow thin-caller is deleted when its `uses:` line still points at the dropped upstream workflow. A locally modified copy (edited content, or a thin-caller carrying extra jobs) is reported for manual review, never deleted. The seed list covers every asset dropped across the project's `gha-utils`, `repokit`, and `repomatic` naming eras, so a repo first set up under an earlier name sheds its legacy files on the next run. The `sync-repomatic` autofix job applies this on every push. Pass `--keep-removed` to report orphans without deleting them, or `--delete-removed-modified` to also delete locally modified ones.
- `/repomatic-ship` now closes with a reflect-and-contribute-back step: once the release PR is ready, it reviews the session for skill, workflow, or convention friction hit during the release and proposes concrete fixes to the upstream `repomatic` source (proposing only, never committing upstream unprompted).
- Fix the downstream caller's `publish-pypi` job aborting every non-release `release.yaml` run with `Unexpected value ''` when evaluating its `strategy`. Its matrix now falls back to an empty `{"include":[]}` matrix when `release_commits_matrix` is empty, since GitHub evaluates `strategy.matrix` even for jobs that `if:` will skip; non-release pushes now skip the job cleanly instead of failing the run.

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.22.0)

#### [`v6.23.0`](https://github.com/kdeldycke/repomatic/releases/tag/v6.23.0)

> [!NOTE]
> `6.23.0` is available on [🐍 PyPI](https://pypi.org/project/repomatic/6.23.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v6.23.0).

- Split `release.yaml` into a thin entry workflow (`release.yaml`, owns `push`/`workflow_dispatch` triggers and the `publish-pypi` job) and a new reusable engine (`_release-engine.yaml`, `workflow_call`-only). Keeping `publish-pypi` in the entry is required so each repo's OIDC `job_workflow_ref` claim resolves to its own `release.yaml` for PyPI's Trusted Publisher (see [pypi/warehouse#11096](https://redirect.github.com/pypi/warehouse/issues/11096)). Downstream repos receive a regenerated `release.yaml` from `sync-repomatic`: its `uses:` line now points at `_release-engine.yaml@vX.Y.Z`, and its `publish-pypi` job is derived from the canonical entry's own job (dogfooding checkout dropped, action ref pinned to release tag, runner changed from `ubuntu-latest` to `ubuntu-slim`). The separate `release-publish-pypi-job.yaml` data fragment is removed; `release.yaml` is the single source for the job, keeping third-party action SHA pins Renovate-visible.
- The vulnerability scan now requires `uv` >= `0.11.15` and parses `uv audit --output-format json` directly, replacing the regex-scraping of `uv audit`'s human-readable text. An older `uv`, or an unrecognized `uv audit` JSON `schema.version`, raises a clear error instead of silently reporting no vulnerabilities. Advisory `aliases` from the structured output drive cross-source deduplication, so an advisory reported by `uv audit` under a PYSEC/OSV ID merges with the same advisory reported by Dependabot under its GHSA ID.

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.23.0)

#### [`v6.24.0`](https://github.com/kdeldycke/repomatic/releases/tag/v6.24.0)

- Split the package build into its own reusable `_release-build.yaml` lane (squash-merge guard, project metadata, and the signed `build-package` job), so the entry `release.yaml`'s `publish-pypi` job depends only on the freshly-built wheel and ships to PyPI right after the build instead of after the whole engine (binary compilation, VirusTotal scan) completes. `_release-engine.yaml` keeps the binary and release-finalization jobs and is gated on the build lane (`needs: build`) so its `create-release` and `sync-dev-release` jobs reuse the same run-scoped wheel (one build, one attestation, shared to both PyPI and the GitHub release). Downstream `release.yaml` is regenerated with three jobs (`build`, `publish-pypi`, `release`) by copying the canonical entry and rewriting each `uses:` to the pinned cross-repo ref; `publish-pypi`'s `package_built`, `release_commits_matrix`, and `release_notes_with_admonition` now come from the build lane.

**Full changelog**: [`v6.23.0...v6.24.0`](https://redirect.github.com/kdeldycke/repomatic/compare/v6.23.0...v6.24.0)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`repomatic-6.24.0-linux-arm64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.24.0/repomatic-6.24.0-linux-arm64.bin) | 0 / 57 | [View scan](https://www.virustotal.com/gui/file/25bf6f4141e9c0ddf92c20c676037a3ff90b04269234ec665bf3b99dd1274104) |
| [`repomatic-6.24.0-linux-x64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.24.0/repomatic-6.24.0-linux-x64.bin) | 1 / 64 | [View scan](https://www.virustotal.com/gui/file/f4d3cb332cae0fafca3428cf114e32ce1da734c9ee7459b482e16a9aea1c981f) |
| [`repomatic-6.24.0-macos-arm64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.24.0/repomatic-6.24.0-macos-arm64.bin) | 1 / 62 | [View scan](https://www.virustotal.com/gui/file/d370c0439ab0a943de83bdce971461bc0786a0deb5c171c947113d733bb0b910) |

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.24.0)

#### [`v6.25.0`](https://github.com/kdeldycke/repomatic/releases/tag/v6.25.0)

- Add man page generation to the release and docs pipelines. A `manpages` job in `_release-engine.yaml`, activated by `[tool.repomatic.manpages]` config keys (`script`, `asset-name`) in `pyproject.toml`, shells out to `click-extra man --output-dir man "${SCRIPT}"` and uploads the rendered roff `.1` files as a `<asset-name>.tar.gz` (defaulting to `<package-name>-manpages.tar.gz`) on the GitHub release; requires `click-extra>=7.19`. The `deploy-docs` job installs `mandoc` alongside Graphviz so projects using `click_extra.sphinx.manpages` get browser-viewable `.html` siblings in the docs build. Both are silently skipped when `manpages.script` is unset.
- Validate `[project.scripts]` entries when assembling the Nuitka build matrix. A script name that PyPI and [uv-build](https://redirect.github.com/astral-sh/uv/pull/19495) would refuse (path-shaped like `../escape` or `nested/script`, empty, dot-only, or containing characters outside `[A-Za-z0-9._-]`) is rejected up front instead of flowing into the binary file path template and release workflow artifact commands. A malformed value (no colon, multiple colons, empty side) raises a descriptive error instead of crashing later with a tuple-unpacking `ValueError`.
- Replace the `tomlkit` dependency with [`tomlrt`](https://dimbleby.github.io/tomlrt/) for all comment-preserving TOML writes. Extend `tomlrt` to all TOML reads too (`pyproject.toml`, `uv.lock`, `[tool.X]` extraction), dropping the `tomli` backport and the conditional `tomllib`/`tomli` import shim previously scattered across eight modules.

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.25.0)

#### [`v6.25.1`](https://github.com/kdeldycke/repomatic/releases/tag/v6.25.1)

- Fix `uvx repomatic@X.Y.Z` failing for end users with `No solution found when resolving tool dependencies` against `bump-my-version`'s `click<8.4` cap and `click-extra>=7.19`'s `click>=8.4.1` floor. Drop `bump-my-version` from `[project].dependencies`: replace `Metadata.get_current_version` with a native `tomlrt` read of `current_version` from `.bumpversion.toml` or `pyproject.toml`'s `[tool.bumpversion]`. Removes the matching `[tool.uv] override-dependencies = ["click>=8.4.1"]`, the `uv-overrides.txt` file, and every `UV_OVERRIDE=uv-overrides.txt` workflow env block (with the `--from .` checkout dance previously needed in `tests.yaml`'s `package-install` job and the `RENOVATE_ALLOWED_COMMANDS` regex alternation in `renovate.yaml`). `ReleasePrep.current_version` now delegates to `Metadata.get_current_version`, picking up `.bumpversion.toml` support and a single source of truth for the search order.
- Render the Mermaid dependency graph (`docs/assets/dependencies.mmd`) in `docs/install.md` under a new `Default dependencies` section, matching `click-extra` and `meta-package-manager`.

**Full changelog**: [`v6.25.0...v6.25.1`](https://redirect.github.com/kdeldycke/repomatic/compare/v6.25.0...v6.25.1)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`repomatic-6.25.1-linux-arm64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.25.1/repomatic-6.25.1-linux-arm64.bin) | 0 / 62 | [View scan](https://www.virustotal.com/gui/file/9cc3215e2df57837878f583a8203db39cd833671c9be546ae9bd466c1ec06f88) |
| [`repomatic-6.25.1-linux-x64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.25.1/repomatic-6.25.1-linux-x64.bin) | 0 / 63 | [View scan](https://www.virustotal.com/gui/file/e0f9e322dc8f3cb8503d0effb4113d2bcf2efd5f0f1f2bf1ffdfa04a8505206a) |

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.25.1)

#### [`v6.26.0`](https://github.com/kdeldycke/repomatic/releases/tag/v6.26.0)

- Add `[tool.repomatic] nuitka.extras` config to sync listed `[project.optional-dependencies]` extras into the venv before the Nuitka build, so optional features land in the binary.
- Add `[tool.repomatic.labels]` `extra`, `file-rules`, and `content-rules` config for inline label definitions and labeller rules, replacing the silently-ignored `extra-file-rules` and `extra-content-rules` fields.
- Stop version-bump PRs from upgrading dependencies: the bump and release jobs now run plain `uv lock`, leaving dependency refreshes to the `sync-uv-lock` job.
- Add a `[tool.repomatic] changelog.bullet-word-threshold` config: `lint-changelog` warns (non-fatally) about unreleased changelog bullets longer than the threshold (40 words by default).

**Full changelog**: [`v6.25.1...v6.26.0`](https://redirect.github.com/kdeldycke/repomatic/compare/v6.25.1...v6.26.0)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`repomatic-6.26.0-linux-arm64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.26.0/repomatic-6.26.0-linux-arm64.bin) | 0 / 58 | [View scan](https://www.virustotal.com/gui/file/20214ab30e43588cee152268526a6ef1ff12b19792dc57d657ed20f0d8a27579) |
| [`repomatic-6.26.0-linux-x64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.26.0/repomatic-6.26.0-linux-x64.bin) | 0 / 63 | [View scan](https://www.virustotal.com/gui/file/6c8f538917f3343c05e15e2c50fdf067e9be90f78b059f2309016076f8b94340) |
| [`repomatic-6.26.0-macos-arm64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.26.0/repomatic-6.26.0-macos-arm64.bin) | 1 / 60 | [View scan](https://www.virustotal.com/gui/file/7fe4599f6e6fa06f35e33e7e2d82b41462b18ab67b30af747b09ea3cd66a4b7c) |

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.26.0)

#### [`v6.27.0`](https://github.com/kdeldycke/repomatic/releases/tag/v6.27.0)

- **Breaking:** Replace `fix-vulnerable-deps` with `audit`. `repomatic audit` reports vulnerable dependencies read-only; `repomatic audit --fix` performs the previous upgrade behavior.
- Stop forcing `pyproject-fmt` table expansion: `project.urls`, `project.scripts`, and similar sections now use its default compact (dotted-key) form.
- Recognize each bundled tool's native config files more accurately (`biome`, `gitleaks`, `ruff`, `typos`, `zizmor`, and others) and their config-file CLI flags.
- Preserve comments when materializing a `[tool.X]` section from `pyproject.toml` to a tool's native TOML config file (like `.gitleaks.toml`), instead of dropping them.
- Update `pyproject-fmt` to `2.25.0`, fixing the `format-pyproject` job writing invalid TOML when it reformats `[tool.repomatic.labels]` rule tables.
- Align the bundled `[tool.bumpversion]` and `[tool.lychee]` templates with `pyproject-fmt`'s canonical output, ending the reformatting pull-request loops they triggered.
- Fix cooldown bypasses (`[tool.uv] exclude-newer-package`) never expiring: `sync-uv-lock` now freezes each one at its locked version instead of a latest-tracking `"0 day"` span, and prunes it once that version ages past `exclude-newer`.
- Fix `uv.lock` ping-ponging on every `sync-uv-lock` run: `exclude-newer-package` freezes are now explicit UTC timestamps, not bare dates that uv re-expands in the locking machine's timezone.
- Fix the `repomatic.myst_docstrings` Sphinx extension corrupting two adjacent inline-code spans in a docstring when the second span starts with an underscore.
- Fix the `manpages` release job: attach the man-page tarball to the release draft before publishing, so it no longer fails under GitHub immutable releases.

**Full changelog**: [`v6.26.0...v6.27.0`](https://redirect.github.com/kdeldycke/repomatic/compare/v6.26.0...v6.27.0)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.27.0)

#### [`v6.28.0`](https://github.com/kdeldycke/repomatic/releases/tag/v6.28.0)

- `repomatic test-plan` runs its cases in parallel by default (one fewer than the CPU count); pass `--jobs 1` for sequential execution.
- Add `[tool.repomatic] test-matrix.full-include` config: declare full-matrix-only job rows as explicit combinations (each merged onto the shipped-config defaults), a readable alternative to a long `test-matrix.exclude` list.
- Run the pull-request test matrix on `ubuntu-24.04-arm` for faster Linux CI; the full test matrix still covers x86 Linux.
- `repomatic metadata` no longer prints spurious `--overwrite` or `$GITHUB_OUTPUT` warnings when writing to stdout.
- Add a [test-matrix guide](https://kdeldycke.github.io/repomatic/test-matrix.html) to the docs: choosing matrix targets, a GitHub-runner speed inventory, and a worked example.

**Full changelog**: [`v6.27.0...v6.28.0`](https://redirect.github.com/kdeldycke/repomatic/compare/v6.27.0...v6.28.0)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`repomatic-6.28.0-linux-arm64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.28.0/repomatic-6.28.0-linux-arm64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/22875eb52255d22c8471dbe7a06f3d2ed8a0fc09092e1b5759646943d69311c5) |
| [`repomatic-6.28.0-linux-x64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.28.0/repomatic-6.28.0-linux-x64.bin) | 0 / 62 | [View scan](https://www.virustotal.com/gui/file/b2ff2d13369240470d68e44582e9602ec121e77c6426103be90f516d6afe3878) |
| [`repomatic-6.28.0-macos-arm64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.28.0/repomatic-6.28.0-macos-arm64.bin) | 1 / 41 | [View scan](https://www.virustotal.com/gui/file/d275f8ffb61900e5236a825e0070498fba5f8173e3ea786287ed0de791a73c79) |

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.28.0)

#### [`v6.28.1`](https://github.com/kdeldycke/repomatic/releases/tag/v6.28.1)

- Fix `test-matrix.full-include` matrices emitting combinations that `exclude` should have removed; they now follow GitHub's documented include/exclude algorithm.

**Full changelog**: [`v6.28.0...v6.28.1`](https://redirect.github.com/kdeldycke/repomatic/compare/v6.28.0...v6.28.1)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`repomatic-6.28.1-linux-arm64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.28.1/repomatic-6.28.1-linux-arm64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/6299fa802b0ac43aed658a8a34b8ba68b8784b1f640915b1a6b8279b41bcc615) |
| [`repomatic-6.28.1-linux-x64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.28.1/repomatic-6.28.1-linux-x64.bin) | 0 / 62 | [View scan](https://www.virustotal.com/gui/file/a2fe92cc5a4142b7bd1ed623d05738d29232b6d23af6487b20c6fadb35088657) |
| [`repomatic-6.28.1-macos-arm64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.28.1/repomatic-6.28.1-macos-arm64.bin) | 1 / 60 | [View scan](https://www.virustotal.com/gui/file/7a6533f64a94c6233865e35b2a0cb1e1481442a83342d171d22ba0df7658b5ba) |
| [`repomatic-6.28.1-macos-x64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.28.1/repomatic-6.28.1-macos-x64.bin) | 1 / 60 | [View scan](https://www.virustotal.com/gui/file/2fae5f2732161e046a82971a32427216a423c0446bb41268b39898335550ebf2) |
| [`repomatic-6.28.1-windows-arm64.exe`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.28.1/repomatic-6.28.1-windows-arm64.exe) | 3 / 65 | [View scan](https://www.virustotal.com/gui/file/0845a34280ae03b6e3dcb5becbf70165f0c67f2a2deab53b62764354b5fb5316) |

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.28.1)

#### [`v6.29.0`](https://github.com/kdeldycke/repomatic/releases/tag/v6.29.0)

- **Breaking:** Remove the `repomatic test-plan` command and `[tool.repomatic] test-plan` config. The declarative test-plan engine moved upstream to [click-extra](https://kdeldycke.github.io/click-extra/test-plan.html); run `click-extra test-plan` instead, configured via `[tool.click-extra.test-plan]`.
- Add `repomatic show-test-matrix` to render the CI test matrix as a Python-version by OS grid in any `--table-format`.
- Add `repomatic init uv` to sync the canonical `[tool.uv]` pins (`required-version`, `exclude-newer`) into `pyproject.toml`; `sync-uv-lock` applies the same sync, so every machine resolves `uv.lock` with the same uv.
- Require `click-extra >= 8`; the `manpages` release job now uses `click-extra wrap --man` to generate man pages.
- The binary download progress bar now respects `--no-progress` and `--accessible`, hiding it when progress output is turned off.
- Move the Sphinx linkcheck output to `docs/_linkcheck/` (mirroring `docs/_build/`); `broken-links --output-json` now defaults there and the generated `.gitignore` excludes it.
- `repomatic run` now warns when `--check` targets a post-processed formatter (currently `mdformat`): check mode bypasses the fixup, so its exit status can mislead.
- `sync-uv-lock` now reverts a re-lock that changed no package versions, so uv's machine-dependent re-spelling of equivalent `uv.lock` environment markers no longer opens empty sync PRs that ping-pong between contributors and CI.
- Documentation pages that cover a Python module now end with that module's API reference.
- Test the free-threaded `3.14t` build as a stable single-runner smoke test instead of across the full cross-platform matrix; `3.15` stays `continue-on-error`.

**Full changelog**: [`v6.28.1...v6.29.0`](https://redirect.github.com/kdeldycke/repomatic/compare/v6.28.1...v6.29.0)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.29.0)

#### [`v6.30.0`](https://github.com/kdeldycke/repomatic/releases/tag/v6.30.0)

- **Breaking:** The test and release workflows now run `click-extra test-suite` (the `test-plan` engine renamed in click-extra `8.1`), reading the suite from `./tests/cli-test-suite.toml`. Requires `click-extra >= 8.1`.
- `repomatic lint-repo` now fails when a workflow's inline `repomatic==X.Y.Z` pin lags the version of its `uses:` ref.
- The test workflow skips the Codecov upload on free-threaded Python (`3.14t`), where codecov-cli cannot build its `test-results-parser` extension.
- In generated dependency graphs, thick arrows now mark only the root package's direct dependencies; a transitive edge that points at a primary dependency stays thin, so optional extras no longer read as a primary dependency chain.
- The release workflow now cancels superseded runs on rapid non-release pushes to `main`, so intermediate commits no longer pile up redundant binary builds; release commits still run to completion.

**Full changelog**: [`v6.29.0...v6.30.0`](https://redirect.github.com/kdeldycke/repomatic/compare/v6.29.0...v6.30.0)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`repomatic-6.30.0-linux-arm64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.30.0/repomatic-6.30.0-linux-arm64.bin) | 0 / 61 | [View scan](https://www.virustotal.com/gui/file/8b3d82a295491b0cfa9e8f1141794288f705fd9bc5b98f9e8ddde94359d30e81) |
| [`repomatic-6.30.0-linux-x64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.30.0/repomatic-6.30.0-linux-x64.bin) | 0 / 62 | [View scan](https://www.virustotal.com/gui/file/661418f811b644ab183ef214aeb7d0733d3c565f2da465d8dd19533b5a83946e) |
| [`repomatic-6.30.0-macos-arm64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.30.0/repomatic-6.30.0-macos-arm64.bin) | 1 / 59 | [View scan](https://www.virustotal.com/gui/file/ed96a49453fad606f5ad44d079cce98d7ca9606637820dae0bfbac6b42039276) |

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.30.0)

#### [`v6.31.0`](https://github.com/kdeldycke/repomatic/releases/tag/v6.31.0)

> [!NOTE]
> `6.31.0` is available on [🐍 PyPI](https://pypi.org/project/repomatic/6.31.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v6.31.0).

- `sync-uv-lock` PRs now list newer releases held back by the `exclude-newer` cooldown, with the date each ages out of the window.
- `sync-uv-lock` package tables now annotate each release date with a relative hint (`2 days ago`, `in 3 days`).
- Autofix PR bodies now document every relevant `[tool.repomatic]` option in their Configuration section.
- The test workflow uploads coverage to Codecov from one runner per OS, not from every matrix cell.
- Drop the Codecov Test Analytics (test results) upload and the `junit.xml` file it generated.
- `update-checksums --registry` now maintains binary tool checksums in a dedicated `repomatic/tool_checksums.py` module.
- Update `pyproject-fmt` to `2.25.1`, which keeps comments inside inline tables when `format-pyproject` reorders their keys.
- Fix the PyPI availability admonition missing from GitHub release notes.
- Fix `repomatic run biome` failing with a SHA-256 mismatch: Biome `2.5.0`'s binary checksums were stale, breaking JSON, JavaScript, and TypeScript format jobs.
- Fix `[tool.repomatic] workflow.sync = false` being ignored: it now skips workflow sync like the other `*.sync` toggles.

**Full changelog**: [`v6.30.0...v6.31.0`](https://redirect.github.com/kdeldycke/repomatic/compare/v6.30.0...v6.31.0)

---

### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`repomatic-6.31.0-linux-arm64.bin`](https://redirect.github.com/kdeldycke/repomatic/releases/download/v6.31.0/repomatic-6.31.0-linux-arm64.bin) | 0 / 62 | [View scan](https://www.virustotal.com/gui/file/4a8cd1c91a410ce3cd782563a994bb7a1942bcff452e5faf09ca9a0800a26fd6) |

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v6.31.0)

</details>

### 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window. Each becomes adoptable on its eligible date.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [repomatic](https://pypi.org/project/repomatic/) | `6.31.0` | `7.0.0` | 2026-07-02 (5 days ago) | 2026-07-10 (in 3 days) |

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`71125fc4`](https://github.com/kdeldycke/extra-platforms/commit/71125fc46441e756bc0ab13cdfe997291f4fc3a3) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/extra-platforms/blob/71125fc46441e756bc0ab13cdfe997291f4fc3a3/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/extra-platforms/blob/71125fc46441e756bc0ab13cdfe997291f4fc3a3/.github/workflows/autofix.yaml) |
| **Run** | [#796.1](https://github.com/kdeldycke/extra-platforms/actions/runs/28896473288) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.0.0`