### PR TITLE
Format `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -320,13 +320,13 @@ build-backend.module-root = ""
 # When merged into pyproject.toml via `repomatic init ruff`,
 # the [tool.ruff] prefix is added automatically.
 [tool.ruff]
+# Enable formatting of Python code blocks in Markdown files.
+# https://docs.astral.sh/ruff/formatter/#markdown-code-formatting
+extend-include = [ "*.{markdown,mdown,mkdn,mdwn,mkd,md,mdtxt,mdtext,mdx}" ]
 preview = true
 fix = true
 unsafe-fixes = true
 show-fixes = true
-# Enable formatting of Python code blocks in Markdown files.
-# https://docs.astral.sh/ruff/formatter/#markdown-code-formatting
-extend-include = [ "*.{markdown,mdown,mkdn,mdwn,mkd,md,mdtxt,mdtext,mdx}" ]
 # Enable reformatting of code snippets in docstrings.
 # https://docs.astral.sh/ruff/formatter/#docstring-formatting
 format.docstring-code-format = true
@@ -348,11 +348,11 @@ lint.extend-select = [ "PLW1514" ]
 #   repomatic's bundled Ruff defaults.
 #   See: https://docs.astral.sh/ruff/rules/root-logger-call/
 lint.ignore = [ "D400", "ERA001", "LOG015" ]
+lint.isort.combine-as-imports = true
 # Allow rules to add `from __future__ import annotations` in cases where
 # this would simplify a fix or enable a new diagnostic.
 # https://docs.astral.sh/ruff/settings/#lint_future-annotations
 lint.future-annotations = true
-lint.isort.combine-as-imports = true
 
 [tool.typos]
 default.extend-identifiers = { Github = "GitHub", IOS = "iOS", Javascript = "JavaScript", MacOS = "macOS", PyPi = "PyPI", Typescript = "TypeScript" }


### PR DESCRIPTION
### Description

Auto-formats `pyproject.toml` with [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt). See the [`format-pyproject` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

> [!TIP]
> Customize formatting rules via [`[tool.pyproject-fmt]`](https://pyproject-fmt.readthedocs.io/en/latest/) in your `pyproject.toml`.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`e561ce3a`](https://github.com/kdeldycke/extra-platforms/commit/e561ce3a1a6ec552dcea52c2daafa5ddd7cfa916) |
| **Job** | [`format-pyproject`](https://github.com/kdeldycke/extra-platforms/blob/e561ce3a1a6ec552dcea52c2daafa5ddd7cfa916/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/extra-platforms/blob/e561ce3a1a6ec552dcea52c2daafa5ddd7cfa916/.github/workflows/autofix.yaml) |
| **Run** | [#807.1](https://github.com/kdeldycke/extra-platforms/actions/runs/28915518451) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.0.0`