### PR TITLE
Bump minor version to `v13.2.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [`13.1.1.dev0` (unreleased)](https://github.com/kdeldycke/extra-platforms/compare/v13.1.0...main)
+## [`13.2.0.dev0` (unreleased)](https://github.com/kdeldycke/extra-platforms/compare/v13.1.0...main)
 
 > [!WARNING]
 > This version is **not released yet** and is under active development.

--- a/citation.cff
+++ b/citation.cff
@@ -1,4 +1,4 @@
-cff-version: 13.1.1.dev0
+cff-version: 13.2.0.dev0
 title: "Extra Platforms"
 message: "If you use this software, please cite it as below."
 type: software
@@ -8,6 +8,6 @@ authors:
     email: kevin@deldycke.com
     orcid: "https://orcid.org/0000-0001-9748-9014"
 doi: 10.5281/zenodo.13341712
-version: 13.1.1.dev0
-date-released: 2026-07-08
+version: 13.2.0.dev0
+date-released: 2026-07-15
 url: "https://github.com/kdeldycke/extra-platforms"

--- a/extra_platforms/__init__.py
+++ b/extra_platforms/__init__.py
@@ -410,7 +410,7 @@ Pytest optional.
 """
 
 
-__version__ = "13.1.1.dev0"
+__version__ = "13.2.0.dev0"
 
 
 def _initialize_group_detection_functions() -> list[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "uv-build>=0.9" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "extra-platforms"
-version = "13.1.1.dev0"
+version = "13.2.0.dev0"
 description = "🔎 Detect architectures, platforms, shells, terminals, CI systems and agents, grouped by family"
 readme = "readme.md"
 keywords = [
@@ -254,7 +254,7 @@ optional-dependencies.pytest = [
 ]
 urls.Changelog = "https://github.com/kdeldycke/extra-platforms/blob/main/changelog.md"
 urls.Documentation = "https://kdeldycke.github.io/extra-platforms"
-urls.Download = "https://github.com/kdeldycke/extra-platforms/releases/tag/v13.1.1.dev0"
+urls.Download = "https://github.com/kdeldycke/extra-platforms/releases/tag/v13.2.0.dev0"
 urls.Funding = "https://github.com/sponsors/kdeldycke"
 urls.Homepage = "https://github.com/kdeldycke/extra-platforms"
 urls.Issues = "https://github.com/kdeldycke/extra-platforms/issues"
@@ -418,7 +418,7 @@ run.source = [ "extra_platforms" ]
 report.precision = 2
 
 [tool.bumpversion]
-current_version = "13.1.1.dev0"
+current_version = "13.2.0.dev0"
 # Parse versions with an optional .devN suffix (PEP 440).
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\.dev(?P<dev>\\d+))?"
 serialize = [

--- a/uv.lock
+++ b/uv.lock
@@ -577,7 +577,7 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "13.1.1.dev0"
+version = "13.2.0.dev0"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -1331,6 +1331,7 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/c4/5628ff7e934621473a024b668f9081a641fcf607303783a7160c700b6497/PyDriller-2.9-py3-none-any.whl", hash = "sha256:bc4e72ff59ce62f1ee4dec77e44103df62b62b6d5ed90daea75abe2eb16c6ebf", size = 36811, upload-time = "2025-09-06T07:40:12.771Z" },
+    { url = "https://files.pythonhosted.org/packages/37/cd/8633b101c28bd124b99c58105ca11be93535a15c159c1168dade1c2a1b2a/pydriller-2.9-py3-none-any.whl", hash = "sha256:092c0d3ea02f559181c78cd38561f589084038362e768c6af35124f7db246abc", size = 37187, upload-time = "2026-07-01T07:36:42.466Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Ready to be merged into `main` branch, at the discretion of the maintainers, to bump the minor part of the version number. Version bumps are scheduled daily and also triggered after releases. See the [`bump-version` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-changelog-yaml-jobs) for details.

### To bump version to `v13.2.0`

1. **Click `Ready for review`** button below, to get this PR out of `Draft` mode

2. **Click `Rebase and merge`** button below


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`e136981b`](https://github.com/kdeldycke/extra-platforms/commit/e136981b6ffb8cd5631affd82bb04c7bcd69ef69) |
| **Job** | [`bump-version`](https://github.com/kdeldycke/extra-platforms/blob/e136981b6ffb8cd5631affd82bb04c7bcd69ef69/.github/workflows/changelog.yaml) |
| **Workflow** | [`changelog.yaml`](https://github.com/kdeldycke/extra-platforms/blob/e136981b6ffb8cd5631affd82bb04c7bcd69ef69/.github/workflows/changelog.yaml) |
| **Run** | [#592.1](https://github.com/kdeldycke/extra-platforms/actions/runs/29442453273) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0`