### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Run repomatic metadata
         id: metadata
         run: >
-          uvx --no-progress 'repomatic==7.0.0' metadata
+          uvx --no-progress 'repomatic==7.1.0' metadata
           --format github-json --output "$GITHUB_OUTPUT"
           coverage_cells test_matrix test_matrix_pr
 
@@ -105,13 +105,13 @@ jobs:
 
       - name: CLI test suite via console script
         run: >
-          uvx --no-progress 'click-extra==8.1.4' test-suite
+          uvx --no-progress 'click-extra==8.2.0' test-suite
           --command "uv run --frozen -- extra-platforms"
           --suite-file tests/cli-test-suite.toml
           --jobs max
       - name: CLI test suite via python -m
         run: >
-          uvx --no-progress 'click-extra==8.1.4' test-suite
+          uvx --no-progress 'click-extra==8.2.0' test-suite
           --command "uv run --frozen -- python -m extra_platforms"
           --suite-file tests/cli-test-suite.toml
           --jobs max


### PR DESCRIPTION
### Description

Bumps npm and PyPI version literals embedded in workflow YAML (`npm install pkg@x`, `uvx '<pkg>==x'`) to their latest releases that have cleared the stabilization cooldown. See the [`sync-workflow-pins` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-07` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.1.4` → `8.2.0` | 2026-07-01 (2 weeks ago) |
| [repomatic](https://pypi.org/project/repomatic/) | `7.0.0` → `7.1.0` |  |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v8.2.0`](https://github.com/kdeldycke/click-extra/releases/tag/v8.2.0)

> [!NOTE]
> `8.2.0` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.2.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.2.0).

- Add a `--export-config FORMAT` option to every `@command` and `@group`: it renders the resolved configuration on `<stdout>` in any writable format (`toml`, `yaml`, `json`, `json5`, `jsonc`, `hjson`, `xml`), then exits. Adds `ExportConfigOption`, `@export_config_option` and `SERIALIZABLE_FORMATS` to the public API.
- Add `--theme=auto`: it selects the `dark` or `light` palette from the terminal background, detected from `CLITHEME`, `COLORFGBG` or a live OSC 11 query; the default stays `dark`. Adds `resolve_background` and `query_osc_background` to `click_extra.color`, `resolve_auto_theme` and `AUTO_THEME` to `click_extra.theme`.
- Add `run_lanes(func, lanes)` and `resolve_jobs(ctx, count)` to `click_extra.execution`: run each lane serially while distinct lanes run concurrently, sized by `--jobs`; expose the worker-count policy shared with `run_jobs`. A `serial_at_debug` keyword collapses both fan-outs to sequential at `DEBUG` verbosity.
- Add the always-on `matrix` Sphinx directive, rendering a package's release compatibility matrix from its git tags, for the Python interpreter (`{matrix} python`) or a dependency (`{matrix} <distribution>`) axis; a comment-marker form renders the embedded table on GitHub too.
- Add the `click-extra refresh-directives` command (wrapping `click_extra.sphinx.matrix.update_matrix_blocks`) to regenerate the tables embedded in `{matrix}` directive blocks and `<!-- matrix … -->` marker regions; its `--check` mode flags stale tables in CI.
- Publish `format_cli_prompt` in `click_extra.testing` (was the private `_format_cli_prompt`): render a themed, copy-pasteable prompt simulating a CLI invocation.

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v8.2.0)

</details>

<details>
<summary><code>repomatic</code></summary>

#### [`v7.1.0`](https://github.com/kdeldycke/repomatic/releases/tag/v7.1.0)

> [!NOTE]
> `7.1.0` is available on [🐍 PyPI](https://pypi.org/project/repomatic/7.1.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v7.1.0).

- **Breaking:** `scan-virustotal` no longer writes scan tables into GitHub release notes; the `--update-release` and `--repo` options are removed, and `--binaries-dir` is now required.
- Add `sync-binaries`: regenerates `docs/assets/binaries.csv` and its `docs/binaries.md` page, a catalog of every released binary with download links, VirusTotal analyses, and a detection trend chart.
- `sync-binaries --backfill-records` recovers detection snapshots from the VirusTotal tables of legacy release notes into the scan history file.
- The release pipeline now records each binary's `flagged / total` snapshot in `docs/assets/virustotal-scans.json` and refreshes the binaries page instead of editing release notes.
- The documentation build gains `sphinx-datatables`, rendering the binaries catalog as a searchable, sortable table; downstream repos can opt in with the same extension.
- Add `git-commit-push`: commits files and pushes them, rebasing and retrying on rejection, for release jobs publishing generated files to the default branch.
- Add a global `--jobs` option controlling how many parallel workers commands may use, defaulting to one fewer than the host's logical CPUs.
- `update-checksums`, `sync-tool-versions`, and `sync-deps` now download artifacts and resolve updates concurrently, sized by `--jobs`; Ctrl+C aborts the fan-out promptly and `--verbosity DEBUG` collapses it to sequential.
- `sync-uv-lock` PR bodies gain a `Cooldown bypasses` section: each active `exclude-newer-package` freeze with the date it expires and is cleared from `pyproject.toml`, plus the entries the run froze or pruned.
- The `Held back by cooldown` table now also lists releases blocked by an `exclude-newer-package` freeze, not only those inside the global `exclude-newer` window.

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v7.1.0)

</details>

### 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window. Each becomes adoptable on its eligible date.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.2.0` | `8.3.0` | 2026-07-08 (a week ago) | 2026-07-16 (in a day) |
| [codecov-cli](https://pypi.org/project/codecov-cli/) | `11.2.8` | `11.3.1` | 2026-07-09 (6 days ago) | 2026-07-17 (in 2 days) |

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`e136981b`](https://github.com/kdeldycke/extra-platforms/commit/e136981b6ffb8cd5631affd82bb04c7bcd69ef69) |
| **Job** | [`sync-deps`](https://github.com/kdeldycke/extra-platforms/blob/e136981b6ffb8cd5631affd82bb04c7bcd69ef69/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/extra-platforms/blob/e136981b6ffb8cd5631affd82bb04c7bcd69ef69/.github/workflows/autofix.yaml) |
| **Run** | [#813.1](https://github.com/kdeldycke/extra-platforms/actions/runs/29442453414) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0`