### PR TITLE
Sync action pins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,7 +46,7 @@ jobs:
       metadata: ${{ steps.metadata.outputs.metadata }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Run repomatic metadata
         id: metadata
         run: >
@@ -71,7 +71,7 @@ jobs:
     continue-on-error: ${{ matrix.state == 'unstable' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Force native ARM64 Python on Windows ARM64
         # Workaround for https://github.com/astral-sh/uv/issues/12906: uv defaults to x86_64 Python on ARM64 Windows,
         # relying on transparent emulation. Native extensions with Rust (e.g., test-results-parser from codecov-cli)
@@ -169,7 +169,7 @@ jobs:
           - windows-2022     # x86
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           # windows-2025 runners have only Python 3.9 installed.
           python-version: ${{ matrix.os == 'windows-2025' && '3.10' || ''}}


### PR DESCRIPTION
## 🆙 Updated actions

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-08` are held back.

| Action | Change | Released |
| :-- | :-- | :-- |
| [astral-sh/setup-uv](https://github.com/astral-sh/setup-uv) | [`v8.3.1` → `v8.3.2`](https://github.com/astral-sh/setup-uv/compare/v8.3.1...v8.3.2) | 2026-07-08 (a week ago) |

### Release notes

<details>
<summary><code>astral-sh/setup-uv</code></summary>

#### [`v8.3.2`](https://github.com/astral-sh/setup-uv/releases/tag/v8.3.2)

##### Changes

Just a maintenance release

##### 🧰 Maintenance

- chore: update known checksums for 0.11.28 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​947)

##### 📚 Documentation

- docs: update version references to v8.3.1 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​946)

##### ⬆️ Dependency updates

- chore: roll up Dependabot updates @​eifinger (#​948)

</details>

## Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`action-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#action-pins-sync)
- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-action-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-action-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`9b7d2839`](https://github.com/kdeldycke/extra-platforms/commit/9b7d2839a0d221378bca16a3dd803b92a3aecf47)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/extra-platforms/blob/9b7d2839a0d221378bca16a3dd803b92a3aecf47/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/extra-platforms/blob/9b7d2839a0d221378bca16a3dd803b92a3aecf47/.github/workflows/autofix.yaml)
- **Run**: [#833.1](https://github.com/kdeldycke/extra-platforms/actions/runs/29514673012)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.2.0`