### PR TITLE
Bump minor version to `v13.3.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [`13.2.1.dev0` (unreleased)](https://github.com/kdeldycke/extra-platforms/compare/v13.2.0...main)
+## [`13.3.0.dev0` (unreleased)](https://github.com/kdeldycke/extra-platforms/compare/v13.2.0...main)
 
 > [!WARNING]
 > This version is **not released yet** and is under active development.

--- a/citation.cff
+++ b/citation.cff
@@ -1,4 +1,4 @@
-cff-version: 13.2.1.dev0
+cff-version: 13.3.0.dev0
 title: "Extra Platforms"
 message: "If you use this software, please cite it as below."
 type: software
@@ -8,6 +8,6 @@ authors:
     email: kevin@deldycke.com
     orcid: "https://orcid.org/0000-0001-9748-9014"
 doi: 10.5281/zenodo.13341712
-version: 13.2.1.dev0
-date-released: 2026-07-15
+version: 13.3.0.dev0
+date-released: 2026-07-16
 url: "https://github.com/kdeldycke/extra-platforms"

--- a/extra_platforms/__init__.py
+++ b/extra_platforms/__init__.py
@@ -412,7 +412,7 @@ Pytest optional.
 """
 
 
-__version__ = "13.2.1.dev0"
+__version__ = "13.3.0.dev0"
 
 
 def _initialize_group_detection_functions() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "uv-build>=0.9" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "extra-platforms"
-version = "13.2.1.dev0"
+version = "13.3.0.dev0"
 description = "🔎 Detect architectures, platforms, shells, terminals, CI systems and agents, grouped by family"
 readme = "readme.md"
 keywords = [
@@ -255,7 +255,7 @@ optional-dependencies.pytest = [
 ]
 urls.Changelog = "https://github.com/kdeldycke/extra-platforms/blob/main/changelog.md"
 urls.Documentation = "https://kdeldycke.github.io/extra-platforms"
-urls.Download = "https://github.com/kdeldycke/extra-platforms/releases/tag/v13.2.1.dev0"
+urls.Download = "https://github.com/kdeldycke/extra-platforms/releases/tag/v13.3.0.dev0"
 urls.Funding = "https://github.com/sponsors/kdeldycke"
 urls.Homepage = "https://github.com/kdeldycke/extra-platforms"
 urls.Issues = "https://github.com/kdeldycke/extra-platforms/issues"
@@ -420,7 +420,7 @@ run.source = [ "extra_platforms" ]
 report.precision = 2
 
 [tool.bumpversion]
-current_version = "13.2.1.dev0"
+current_version = "13.3.0.dev0"
 # Parse versions with an optional .devN suffix (PEP 440).
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\.dev(?P<dev>\\d+))?"
 serialize = [

--- a/uv.lock
+++ b/uv.lock
@@ -559,7 +559,7 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "13.2.1.dev0"
+version = "13.3.0.dev0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
### Description

Ready to be merged into `main` branch, at the discretion of the maintainers, to bump the minor part of the version number. Version bumps are scheduled daily and also triggered after releases. See the [`bump-version` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-changelog-yaml-jobs) for details.

### To bump version to `v13.3.0`

1. **Click `Ready for review`** button below, to get this PR out of `Draft` mode

2. **Click `Rebase and merge`** button below


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`6fa0487b`](https://github.com/kdeldycke/extra-platforms/commit/6fa0487b381ac721a86f88eb10c0e5a76aca0f69) |
| **Job** | [`bump-version`](https://github.com/kdeldycke/extra-platforms/blob/6fa0487b381ac721a86f88eb10c0e5a76aca0f69/.github/workflows/changelog.yaml) |
| **Workflow** | [`changelog.yaml`](https://github.com/kdeldycke/extra-platforms/blob/6fa0487b381ac721a86f88eb10c0e5a76aca0f69/.github/workflows/changelog.yaml) |
| **Run** | [#602.1](https://github.com/kdeldycke/extra-platforms/actions/runs/29476928878) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0`