### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Run repomatic metadata
         id: metadata
         run: >
-          uvx --no-progress 'repomatic==7.1.0' metadata
+          uvx --no-progress 'repomatic==7.2.0' metadata
           --format github-json --output "$GITHUB_OUTPUT"
           coverage_cells test_matrix test_matrix_pr
 
@@ -105,13 +105,13 @@ jobs:
 
       - name: CLI test suite via console script
         run: >
-          uvx --no-progress 'click-extra==8.2.0' test-suite
+          uvx --no-progress 'click-extra==8.3.0' test-suite
           --command "uv run --frozen -- extra-platforms"
           --suite-file tests/cli-test-suite.toml
           --jobs max
       - name: CLI test suite via python -m
         run: >
-          uvx --no-progress 'click-extra==8.2.0' test-suite
+          uvx --no-progress 'click-extra==8.3.0' test-suite
           --command "uv run --frozen -- python -m extra_platforms"
           --suite-file tests/cli-test-suite.toml
           --jobs max
@@ -144,7 +144,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         shell: bash
         run: >
-          uvx --no-progress 'codecov-cli==11.2.8'
+          uvx --no-progress 'codecov-cli==11.3.0'
           --auto-load-params-from githubactions
           upload-process
           --git-service github


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-08` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.2.0` → `8.3.0` | 2026-07-08 (a week ago) |
| [codecov-cli](https://pypi.org/project/codecov-cli/) | `11.2.8` → `11.3.0` | 2026-07-08 (a week ago) |
| [repomatic](https://pypi.org/project/repomatic/) | `7.1.0` → `7.2.0` |  |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v8.3.0`](https://github.com/kdeldycke/click-extra/releases/tag/v8.3.0)

> [!NOTE]
> `8.3.0` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.3.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.3.0).

- Add a `click:config` Sphinx directive documenting a CLI's `config_schema`: a summary table plus one section per option, with docstring, type, default, and a TOML example. Adds `schema_field_infos()`, `field_docstrings()` and `SchemaFieldInfo` to the public API.
- Disable mouse zoom on the class inheritance diagrams of the documentation's API sections, so they no longer hijack page scrolling; the fullscreen viewer keeps zoom.
- Add tests covering 256-color palette index `0` and empty-string colors in `Style`, gated on runtime probes of Click `8.5.0`'s color validation.

**Full changelog**: [`v8.2.0...v8.3.0`](https://redirect.github.com/kdeldycke/click-extra/compare/v8.2.0...v8.3.0)

---

##### 🛡️ VirusTotal scans

| Binary | Detections | Analysis |
| --- | --- | --- |
| [`click-extra-8.3.0-linux-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.3.0/click-extra-8.3.0-linux-arm64.bin) | 1 / 62 | [View scan](https://www.virustotal.com/gui/file/223c214c34b4776bd8374e5505c38917c0213dee574c539a27060cee1f94b7a2) |
| [`click-extra-8.3.0-linux-x64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.3.0/click-extra-8.3.0-linux-x64.bin) | 1 / 64 | [View scan](https://www.virustotal.com/gui/file/d5afe22fb8402326f758c22e6a96088bf9c7d47241df9a4aa60af59b658e0bb6) |
| [`click-extra-8.3.0-macos-arm64.bin`](https://redirect.github.com/kdeldycke/click-extra/releases/download/v8.3.0/click-extra-8.3.0-macos-arm64.bin) | 1 / 61 | [View scan](https://www.virustotal.com/gui/file/ff40b1162adc553a63e5e34b52e7b3f5ab0b120b18ee52be1717d24412791792) |

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v8.3.0)

</details>

<details>
<summary><code>repomatic</code></summary>

[Changelog](https://redirect.github.com/kdeldycke/repomatic/blob/main/changelog.md)

</details>

## 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [codecov-cli](https://pypi.org/project/codecov-cli/) | `11.3.0` | `11.3.1` | 2026-07-09 (a week ago) | 2026-07-17 (in a day) |

## Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`9b7d2839`](https://github.com/kdeldycke/extra-platforms/commit/9b7d2839a0d221378bca16a3dd803b92a3aecf47)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/extra-platforms/blob/9b7d2839a0d221378bca16a3dd803b92a3aecf47/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/extra-platforms/blob/9b7d2839a0d221378bca16a3dd803b92a3aecf47/.github/workflows/autofix.yaml)
- **Run**: [#833.1](https://github.com/kdeldycke/extra-platforms/actions/runs/29514673012)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.2.0`