### PR TITLE
Sync `bump-my-version` config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -475,13 +475,9 @@ search = "## [`{current_version}` (unreleased)]("
 replace = "## [`{new_version}` (unreleased)]("
 
 [[tool.bumpversion.files]]
-# Update the version in the citation file. Anchored to a line start (regex) so
-# it does not also match the `cff-version:` schema field, which would otherwise
-# be overwritten with the package version on every bump as soon as the two
-# values coincide once.
+# Update the version in the citation file.
 filename = "./citation.cff"
-regex = true
-search = "(?m)^version: {current_version}"
+search = "version: {current_version}"
 replace = "version: {new_version}"
 
 [[tool.bumpversion.files]]


### PR DESCRIPTION
### Description

Initializes the `[tool.bumpversion]` configuration in `pyproject.toml` from the [bundled template](https://github.com/kdeldycke/repomatic/blob/main/repomatic/data/bumpversion.toml). See the [`sync-bumpversion` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`bumpversion.sync`](https://kdeldycke.github.io/repomatic/configuration.html#bumpversion-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`4bd80343`](https://github.com/kdeldycke/extra-platforms/commit/4bd8034309dfa9799ad1ac06176e70f7ac4d9ddc) |
| **Job** | [`sync-bumpversion`](https://github.com/kdeldycke/extra-platforms/blob/4bd8034309dfa9799ad1ac06176e70f7ac4d9ddc/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/extra-platforms/blob/4bd8034309dfa9799ad1ac06176e70f7ac4d9ddc/.github/workflows/autofix.yaml) |
| **Run** | [#831.1](https://github.com/kdeldycke/extra-platforms/actions/runs/29499465280) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.1.0`