### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1752,11 +1752,11 @@ wheels = [
 
 [[package]]
 name = "tzdata"
-version = "2026.2"
+version = "2026.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]
@@ -1783,14 +1783,14 @@ wheels = [
 
 [[package]]
 name = "wcmatch"
-version = "10.2.1"
+version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bracex" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/15/dc61746d8c0852f6d711ad09c774b63cf7c8211aa49e30871ac3d342b7e2/wcmatch-10.2.1.tar.gz", hash = "sha256:ecac70a5c70e62ba854b78318d3a1408e8651f8f1c96e5837743b71aa6a4fb92", size = 132497, upload-time = "2026-07-02T17:21:48.484Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/25/1da725838132221e33568973da484ff43813662ccc06ebf7f6e3abddfcd5/wcmatch-11.0.tar.gz", hash = "sha256:55d95c2447789712774b198ceec72939e88b5618f1f8f0a9b605bf7740b63b96", size = 141360, upload-time = "2026-07-10T05:50:24.183Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/ba/20b48eedeab5316bf9a502bb9eb7e3b1588bd61d0f565822fefa8f06e10b/wcmatch-10.2.1-py3-none-any.whl", hash = "sha256:2d775395b93f233af66690f62cb9d52b084ec159a31cc4084f4069d72f437acd", size = 39763, upload-time = "2026-07-02T17:21:47.134Z" },
+    { url = "https://files.pythonhosted.org/packages/28/12/f38b6fee116274d7221743caab07d765032e1370bb54cad8714f87aeb0e8/wcmatch-11.0-py3-none-any.whl", hash = "sha256:3a5977ace27e075eef67eb03d539563f1a19018b62881949a42932cf66926934", size = 42914, upload-time = "2026-07-10T05:50:22.995Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-07-10`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [tzdata](https://pypi.org/project/tzdata/) | [`2026.2` → `2026.3`](https://github.com/python/tzdata/compare/2026.2...2026.3) | 2026-07-10 (a week ago) |
| [wcmatch](https://pypi.org/project/wcmatch/) | [`10.2.1` → `11.0`](https://github.com/facelessuser/wcmatch/compare/10.2.1...11.0) | 2026-07-10 (a week ago) |

### Release notes

<details>
<summary><code>tzdata</code></summary>

#### [`2026.3`](https://github.com/python/tzdata/releases/tag/2026.3)

##### Version 2026.3

Upstream version 2026c released 2026-07-08T17:23:58+00:00

###### Briefly:

Alberta moved to permanent -06 on 2026-06-18. Morocco moves to permanent +00 on
2026-09-20. More integer overflow bugs have been fixed in zic.

###### Changes to future timestamps

Alberta’s 2026-03-08 spring forward was its last foreseeable clock change, as it
moved to permanent -06 thereafter.  (Thanks to Roozbeh Pournader and others.)
Model this with its traditional abbreviation CST.  Although the change to
permanent -06 legally took place on 2026-06-18, temporarily model the change to
occur on 2026-11-01 at 02:00 instead, for the same reason we introduced a
similarly temporary hack for British Columbia in 2026b.

Although another TZDB release will likely be needed soon because Northwest
Territories will likely follow Alberta, the legal formalities have not yet taken
place.

Morocco plans to move back to permanent UTC, without daylight saving time
transitions, on 2026-09-20 at 02:00.  This also affects Western Sahara.

###### Changes to commentary

Northwest Territories is expected to move to permanent -06 prior to 2026-11-01
02:00, when clocks would otherwise fall back.  (Thanks to Tim Parenti and James
Bellaire.)  Model this with its traditional abbreviation CST.  Unfortunately the
change is not yet official, so it is currently present only as comments that can
be uncommented as needed.

</details>

<details>
<summary><code>wcmatch</code></summary>

#### [`11.0`](https://github.com/facelessuser/wcmatch/releases/tag/11.0)

##### 11.0

-   **NEW**: Reduce/combine nested `EXTGLOB`/`EXTMATCH` regular expression patterns when possible to reduce deeply
    nested patterns.
-   **NEW**: Added ZSH style numerical ranges (`<0-9>`) via new `NUMRANGE` flag.
-   **BREAK**: Previously, translation would have a capture group for every extended glob pattern when
    `EXTGLOB`/`EXTMATCH` was enabled. Due to the new feature added that reduces extended glob group nesting, groups no
    longer appear exactly as specified. Moving forward, capturing groups are not included by default. If you need the
    old behavior, it can be enabled in a `translate()` call via the `CAPTURE` flag. This flag will cause extended glob
    reduction to be turned off and for capturing groups to be enabled.
-   **FIX**: Avoid reparsing sequences that have already been deemed not valid.
-   **FIX**: Halt `EXTGLOB`/`EXTMATCH` parsing once an unclosed extended glob pattern is encountered.
-   **FIX**: Fix case where an empty string would not match a pattern targeting an empty string.
-   **FIX**: Ensure that consecutive stars are collapsed into a single regular expression pattern.
-   **FIX**: Fix parsing `SPLIT` not accounting for POSIX character class.

</details>

## 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.3.0` | `8.4.0` | 2026-07-16 (a day ago) | 2026-07-23 (in 6 days) |
| [coverage](https://pypi.org/project/coverage/) | `7.15.0` | `7.15.2` | 2026-07-15 (2 days ago) | 2026-07-22 (in 5 days) |
| [repomatic](https://pypi.org/project/repomatic/) | `7.1.0` | `7.2.0` | 2026-07-16 (a day ago) | 2026-07-23 (in 6 days) |
| [tomlrt](https://pypi.org/project/tomlrt/) | `2.0.1` | `2.0.2` | 2026-07-10 (a week ago) | 2026-07-17 (just now) |

## Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`7b799a15`](https://github.com/kdeldycke/extra-platforms/commit/7b799a15e4d64aaf4d884dc2a1331805f08bbe34)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/extra-platforms/blob/7b799a15e4d64aaf4d884dc2a1331805f08bbe34/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/extra-platforms/blob/7b799a15e4d64aaf4d884dc2a1331805f08bbe34/.github/workflows/autofix.yaml)
- **Run**: [#838.1](https://github.com/kdeldycke/extra-platforms/actions/runs/29571392735)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.2.0`