### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -144,7 +144,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         shell: bash
         run: >
-          uvx --no-progress 'codecov-cli==11.3.0'
+          uvx --no-progress 'codecov-cli==11.3.1'
           --auto-load-params-from githubactions
           upload-process
           --git-service github


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-09` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [codecov-cli](https://pypi.org/project/codecov-cli/) | `11.3.0` → `11.3.1` | 2026-07-09 (a week ago) |

## 🔜 Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.3.0` | `8.4.0` | 2026-07-16 (a day ago) | 2026-07-24 (in a week) |

## Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`994a6f17`](https://github.com/kdeldycke/extra-platforms/commit/994a6f1780b09649e20ed3ff4a230e411b749e54)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/extra-platforms/blob/994a6f1780b09649e20ed3ff4a230e411b749e54/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/extra-platforms/blob/994a6f1780b09649e20ed3ff4a230e411b749e54/.github/workflows/autofix.yaml)
- **Run**: [#836.1](https://github.com/kdeldycke/extra-platforms/actions/runs/29568822300)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.2.0`