### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Run repomatic metadata
         id: metadata
         run: >
-          uvx --no-progress 'repomatic==7.3.0' metadata
+          uvx --no-progress 'repomatic==7.4.0' metadata
           --format github-json --output "$GITHUB_OUTPUT"
           coverage_cells test_matrix test_matrix_pr
 
@@ -122,13 +122,13 @@ jobs:
 
       - name: CLI test suite via console script
         run: >
-          uvx --no-progress 'click-extra==8.5.0' test-suite
+          uvx --no-progress 'click-extra==8.6.0' test-suite
           --command "uv run --frozen -- extra-platforms"
           --suite-file tests/cli-test-suite.toml
           --jobs max
       - name: CLI test suite via python -m
         run: >
-          uvx --no-progress 'click-extra==8.5.0' test-suite
+          uvx --no-progress 'click-extra==8.6.0' test-suite
           --command "uv run --frozen -- python -m extra_platforms"
           --suite-file tests/cli-test-suite.toml
           --jobs max


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-24` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.5.0` → `8.6.0` | 2026-07-24 (a week ago) |
| [repomatic](https://pypi.org/project/repomatic/) | `7.3.0` → `7.4.0` | [⛓️ lockstep with `uses:` refs](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater) |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v8.6.0`](https://github.com/kdeldycke/click-extra/releases/tag/v8.6.0)

> [!NOTE]
> `8.6.0` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.6.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.6.0).

- Add `OperationTrail`, the batch-reporting companion of `run_jobs`/`run_lanes`: each operation leaves a persistent `✓`/`✘` line and the batch closes with a timed summary. Adds the `trail_glyph` and `trail_line` helpers.
- Add `column-order` and `row-order` options to `{matrix}` blocks (`newest-first`/`oldest-first`), defaulting both axes to `newest-first` so the most recent compatibility information reads from the upper-left corner.
- Refresh each `python:render` `:mirror:` block through `click-extra refresh-directives` with the source file's directory on `sys.path`, so a block importing a sibling helper module resolves offline as it does at build time.
- Fix `test-suite --command` resolving a venv's symlinked Python interpreter (`.venv/bin/python`) to its base target, silently dropping the venv's installed packages.
- Upload coverage from the once-only test job to Codecov, and move the package-install CLI checks to a dedicated CI job skipped on pull requests.

**Full changelog**: [`v8.5.0...v8.6.0`](https://redirect.github.com/kdeldycke/click-extra/compare/v8.5.0...v8.6.0)

</details>

<details>
<summary><code>repomatic</code></summary>

#### [`v7.3.1`](https://github.com/kdeldycke/repomatic/releases/tag/v7.3.1)

> [!NOTE]
> `7.3.1` is available on [🐍 PyPI](https://pypi.org/project/repomatic/7.3.1/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v7.3.1).

- Refresh the bundled pytest defaults to the canonical configuration: `importlib` import mode, `tests/`-restricted collection, the `once` marker, parallel runs via `pytest-xdist`, and `--cov-report=xml` left to the test workflow's command line.
- Mark the `validate-arch` job of `tests.yaml` as canonical-repository-only: downstream repos drop the job and its `build_targets` metadata field when adapting the workflow.
- Point the `lint-changelog` `not found on PyPI` warning at its remedy: list intentionally-unpublished releases under `[tool.repomatic] abandoned-versions`.
- Fix the post-release re-trigger of `changelog.yaml`: its `workflow_run` filter still watched the pre-emoji `Build & release` workflow name and never fired.
- Fix `lint-changelog --fix` treating a published pre-release (`X.Y.Z.dev0`, `rc`, `alpha`, `beta`) as a missing changelog entry, which inserted a spurious section and rewrote the adjacent release's comparison URL.
- Fix the `update-docs` autofix job opening a duplicate of the `format-pyproject` pull request: it now reformats `pyproject.toml` only when `update-docs` changed it.
- Skip the bare `uvx <script>` invocation of the package-install smoke job when the CLI script is not named after its package.
- Restructure the `repomatic-ship` skill: rules shared by every spawned agent move to a single section, and accumulated incident notes compress into their operative rules.
- Harden the `repomatic-ship` release checks: dispatch `release.yaml` past a content-skipped binary matrix, revert formatter moves whole, read the freeze scope from the regenerated release PR, and verify `{click:run}` blocks against the live CLI.
- Direct the `repomatic-ship` docs pass to advance version samples lagging the released tag up to it.

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v7.3.1)

#### [`v7.4.0`](https://github.com/kdeldycke/repomatic/releases/tag/v7.4.0)

> [!NOTE]
> `7.4.0` is available on [🐍 PyPI](https://pypi.org/project/repomatic/7.4.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v7.4.0).

- **Breaking:** Regroup the internal module layout: the tool catalog to `tool_registry.py`, dep-report rendering to `dep_report.py`, labels to `labels.py`, bundled data to `bundle.py`, matrix axes to `matrix_axes.py` (formerly `test_matrix.py`), PR helpers to `github/issue.py`. Import paths change; the CLI surface does not.
- **Breaking:** Rename `update-deps-graph` to `update-dep-graph` across the CLI command, autofix job, PR branch, and body template, aligning with the `dependency-graph` config key. Close any open `update-deps-graph` pull request; the next run reopens it on the new branch.
- **Breaking:** `repomatic init` component selectors are now case-sensitive, validated by the same code path as the `exclude` and `include` configuration entries.
- Lower the compiled-binary OS floors: Linux glibc `2.28`, built and self-tested in `manylinux_2_28` containers (RHEL 8, Debian 10, Ubuntu 20.04 and later), and macOS `11.0` (Apple silicon) / `10.15` (Intel) via uv's embedded python-build-standalone interpreter.
- Enforce each binary's OS floor at build time: `verify-binary` parses ELF, Mach-O and PE headers natively and no longer needs exiftool.
- Keep `tkinter` and its Tcl/Tk stack out of compiled binaries via the new `[tool.repomatic]` `nuitka.nofollow-imports` setting (default `["tkinter"]`, set to `[]` to bundle it).
- Emit man pages for repomatic's own CLI on docs builds and attach a `repomatic-manpages.tar.gz` asset to each release.
- Add `update-docs --check` to report out-of-date self-updating content and exit non-zero without writing, for CI drift detection. The docs update script must accept its own `--check` flag to participate.

... [Full release notes](https://github.com/kdeldycke/repomatic/releases/tag/v7.4.0)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.6.0` | `8.8.0` | 2026-07-31 (a day ago) | 2026-08-08 (in a week) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`40b8feaf`](https://github.com/kdeldycke/extra-platforms/commit/40b8feaf1b2d80d78cb18afc94c8b17ab884eadd)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/extra-platforms/blob/40b8feaf1b2d80d78cb18afc94c8b17ab884eadd/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/extra-platforms/blob/40b8feaf1b2d80d78cb18afc94c8b17ab884eadd/.github/workflows/autofix.yaml)
- **Run**: [#888.1](https://github.com/kdeldycke/extra-platforms/actions/runs/30695804161)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.4.0`