### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Run repomatic metadata
         id: metadata
         run: >
-          uvx --no-progress 'repomatic==7.4.0' metadata
+          uvx --no-progress 'repomatic==7.4.1' metadata
           --format github-json --output "$GITHUB_OUTPUT"
           coverage_cells test_matrix test_matrix_pr
 


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-24` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [repomatic](https://pypi.org/project/repomatic/) | `7.4.0` → `7.4.1` | [⛓️ lockstep with `uses:` refs](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater) |

### Release notes

<details>
<summary><code>repomatic</code></summary>

#### [`v7.4.1`](https://github.com/kdeldycke/repomatic/releases/tag/v7.4.1)

> [!NOTE]
> `7.4.1` is available on [🐍 PyPI](https://pypi.org/project/repomatic/7.4.1/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/repomatic/releases/tag/v7.4.1).

- Add two review links to the release PR's `How-to release` checklist: the draft dev pre-release and the full changes against `main`.
- Teach the `repomatic-ship` pre-push gate to read the latest conclusive ancestor CI run when HEAD's own runs are still in-flight, catching a pre-existing platform-gated failure before the first push.
- Lower the uv `required-version` floor from `>=0.12` to `>=0.11.15`, the actual resolver minimum.
- Extend the `uvx` script-equals-package guard to the `pipx run <script>` install check, so `📦 Package install` no longer fails permanently for projects whose CLI script differs from their package name.

**Full changelog**: [`v7.4.0...v7.4.1`](https://redirect.github.com/kdeldycke/repomatic/compare/v7.4.0...v7.4.1)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.6.0` | `8.8.0` | 2026-07-31 (a day ago) | 2026-08-08 (in a week) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`4e675b5b`](https://github.com/kdeldycke/extra-platforms/commit/4e675b5be72a4349d4f4ef3c0c9776ad00ea17bd)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/extra-platforms/blob/4e675b5be72a4349d4f4ef3c0c9776ad00ea17bd/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/extra-platforms/blob/4e675b5be72a4349d4f4ef3c0c9776ad00ea17bd/.github/workflows/autofix.yaml)
- **Run**: [#897.1](https://github.com/kdeldycke/extra-platforms/actions/runs/30707096728)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.4.1`