### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -148,13 +148,13 @@ jobs:
 
       - name: CLI test suite via console script
         run: >
-          uvx --no-progress 'click-extra==8.6.0' test-suite
+          uvx --no-progress 'click-extra==8.8.1' test-suite
           --command "uv run --frozen -- extra-platforms"
           --suite-file tests/cli-test-suite.toml
           --jobs max
       - name: CLI test suite via python -m
         run: >
-          uvx --no-progress 'click-extra==8.6.0' test-suite
+          uvx --no-progress 'click-extra==8.8.1' test-suite
           --command "uv run --frozen -- python -m extra_platforms"
           --suite-file tests/cli-test-suite.toml
           --jobs max


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `1 week`: releases after `2026-08-07` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.6.0` → `8.8.1` | 2026-08-02 (a week ago) |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v8.6.1`](https://github.com/kdeldycke/click-extra/releases/tag/v8.6.1)

> [!NOTE]
> `8.6.1` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.6.1/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.6.1).

- **Deprecated:** `ClickExtraConfig`, `PrebakeConfig` and `TestSuiteConfig` resolve again from the top-level `click_extra` namespace, warning and redirecting to `click_extra.config`; removed in `9.0.0`.
- **Deprecated:** The `click_extra.test_plan` module and the top-level `TestPlanConfig`, `parse_test_plan`, `run_test_plan` and `DEFAULT_TEST_PLAN` names warn and resolve to their `test_suite` replacements; removed in `9.0.0`.
- **Deprecated:** `prebake_dunder`, `prebake_version` and `discover_package_init_files` resolve again from `click_extra.version`, warning and redirecting to `click_extra.prebake`; removed in `9.0.0`.
- **Deprecated:** Importing `INDENT`, `PROMPT`, `args_cleanup` or `format_cli_prompt` from `click_extra.testing` now warns and redirects to `click_extra.execution`; removed in `9.0.0`.
- Ship the test suite and the docs and CI files it reads in the PyPI sdist, so downstream packagers can build and test without a Git checkout.
- Add a `[tool.setuptools]` shim so builds that fall back to setuptools still bundle the `themes.toml` and `py.typed` data files.
- Fix the source line reported in `click:run` variable-conflict errors when a MyST directive's body ends in blank lines.
- Fix the MkDocs test tree erroring instead of self-skipping when `mkdocs-click` is absent but `mkdocs` and `pymdown-extensions` are present.

**Full changelog**: [`v8.6.0...v8.6.1`](https://redirect.github.com/kdeldycke/click-extra/compare/v8.6.0...v8.6.1)

#### [`v8.6.2`](https://github.com/kdeldycke/click-extra/releases/tag/v8.6.2)

> [!NOTE]
> `8.6.2` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.6.2/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.6.2).

- Treat an unreaped zombie as a dead process in the `run_cli` process-group teardown tests, so they pass in a build sandbox with no init to reap orphans (like Alpine's `abuild` container).

**Full changelog**: [`v8.6.1...v8.6.2`](https://redirect.github.com/kdeldycke/click-extra/compare/v8.6.1...v8.6.2)

#### [`v8.6.3`](https://github.com/kdeldycke/click-extra/releases/tag/v8.6.3)

> [!NOTE]
> `8.6.3` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.6.3/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.6.3).

- Stop importing the test tooling at package import time: the `click_extra.testing` and `click_extra.test_suite` exports now resolve lazily, keeping Click's debugger stack out of importing programs and compiled binaries.
- Scrub the submodule objects star imports leaked into the package namespace: foreign modules like `click_extra.core` and `click_extra.termui` no longer hand out Click's un-enhanced classes or shadow the `globals` builtin.
- Pin `[tool.repomatic]` `nuitka.nofollow-imports` to its bare `["tkinter"]` default, ahead of the repomatic release introducing the setting.
- Fix the `myst_docstrings` MyST-to-reST converter mispairing inline-code backticks and emitting reST literals with illegal edge whitespace from padded code spans.

**Full changelog**: [`v8.6.2...v8.6.3`](https://redirect.github.com/kdeldycke/click-extra/compare/v8.6.2...v8.6.3)

#### [`v8.7.0`](https://github.com/kdeldycke/click-extra/releases/tag/v8.7.0)

> [!NOTE]
> `8.7.0` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.7.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.7.0).

- Add a `<!-- mirror-src -->` comment form of `python:render` `:mirror:`: the generator Python lives inside an HTML comment, so its output renders on GitHub and PyPI while the generator stays invisible.
- Export `update_blocks`, `marker_res`, and a new `replace_region` helper from `click_extra.sphinx` for downstream self-updating documentation scripts.
- Accept kebab-case keys in configuration files: `dummy-flag` and `dummy_flag` both address the `--dummy-flag` option, the last spelling winning on collision with a warning.
- Scope the configuration strict check and merge to the app's own section, ignoring other tools' sections in shared files like `pyproject.toml`.
- Honor legacy `fallback_sections` when merging configuration values into `default_map`, not only in the schema path.
- Forward `config_strict` and additive `excluded_params` from `@command`/`@group` to the default `--config` option.
- Load the configuration file before `--params` and `--export-config` render, so both reflect it whatever the order of the flags.
- Export parameters without a value in `--export-config`: empty lists for multi-value options, `null` in YAML and JSON, commented-out keys in TOML.
- Render `--export-config` keys in kebab-case, the canonical spelling for configuration files, matching the CLI flags.
- Exclude `--validate-config` from configuration files, like the other self-referential config options.
- Reword the unknown-configuration-key error, and report parameters blocked from configuration files as not allowed instead of unknown.
- Fix `DO_NOT_TRACK` handling: a truthy value now forces `--telemetry` off; it previously fed the boolean flag verbatim and enabled telemetry.
- Add an executables download table and a release-verification section to the installation guide.

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v8.7.0)

#### [`v8.8.0`](https://github.com/kdeldycke/click-extra/releases/tag/v8.8.0)

> [!NOTE]
> `8.8.0` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.8.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.8.0).

- **Breaking:** `OperationTrail` now gates its per-item and finisher elapsed times on a new `timer` argument that defaults to `None`, following `--time` / `--no-time`; its finisher no longer always shows a clock (pass `timer=True` to restore it).
- Add `spinner` and `progress_bar` arguments to `OperationTrail` to render its concurrent aggregate indicator as a spinner from the `SPINNERS` catalog or a determinate progress bar. Closes [#​1860](https://redirect.github.com/kdeldycke/click-extra/issues/1860).
- Add a `clock` argument to `OperationTrail` (`"elapsed"` by default, or `"eta"`), choosing whether a running spinner or bar counts elapsed time up or estimated time remaining down.
- Add an `OperationTrail.operation()` handle whose `mark()` records an outcome timed from when the operation began.
- Render the `OperationTrail` sequential finish-line elapsed time in the compact clock format, so a run past a minute reads `1:15`, not `75.3s`.
- Gate the estimated-time display of `click_extra.progressbar` on `--time` through a new tri-state `show_eta` argument (default `None`; Click's own default is `True`).
- Add a `trail` demo subcommand to the `click-extra` CLI, running a simulated batch behind an `OperationTrail` to showcase its sequential, spinner and progress-bar renderings in a real terminal.
- Move the self-updating block primitives (`update_blocks`, `marker_res`, `replace_region`) to a new dependency-light `click_extra.blocks` module, importable without the `sphinx` extra; they stay re-exported from `click_extra.sphinx`.
- Add a `pad` option to `replace_region` to keep the closing marker flush against the body, for regions constrained by `mdformat-footnote`.

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v8.8.0)

#### [`v8.8.1`](https://github.com/kdeldycke/click-extra/releases/tag/v8.8.1)

> [!NOTE]
> `8.8.1` is available on [🐍 PyPI](https://pypi.org/project/click-extra/8.8.1/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v8.8.1).

- Widen the `[tool.uv]` `required-version` to `>=0.11.15` and the `[build-system]` `uv-build` floor to `>=0.8`, dropping the previous `<0.13` upper cap.

**Full changelog**: [`v8.8.0...v8.8.1`](https://redirect.github.com/kdeldycke/click-extra/compare/v8.8.0...v8.8.1)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [uv](https://pypi.org/project/uv/) | `0.12.2` | `0.12.4` | 2026-08-13 (a day ago) | 2026-08-20 (in 6 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)
- [`workflow-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`fe13ebd0`](https://github.com/kdeldycke/extra-platforms/commit/fe13ebd0c8cbe3351ed4c773951460d4b578540c)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/extra-platforms/blob/fe13ebd0c8cbe3351ed4c773951460d4b578540c/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/extra-platforms/blob/fe13ebd0c8cbe3351ed4c773951460d4b578540c/.github/workflows/autofix.yaml)
- **Run**: [#912.1](https://github.com/kdeldycke/extra-platforms/actions/runs/31783053005)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.11.0`
