### PR TITLE
Sync action pins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -78,7 +78,7 @@ jobs:
       metadata: ${{ steps.metadata.outputs.metadata }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.2"
       - name: Run repomatic metadata
@@ -111,7 +111,7 @@ jobs:
     continue-on-error: ${{ matrix.state == 'unstable' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.2"
       - name: Force native ARM64 Python on Windows ARM64
@@ -210,7 +210,7 @@ jobs:
       # on a throwaway runner.
       UV_EXCLUDE_NEWER: P0D
     steps:
-      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           # windows-2025 runners have only Python 3.9 installed.
           python-version: ${{ matrix.os == 'windows-2025' && '3.10' || ''}}


### PR DESCRIPTION
## 🆙 Updated actions

Resolved with [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age) cooldown `1 week`: releases after `2026-08-21` are held back.

| Action | Change | Released |
| :-- | :-- | :-- |
| [astral-sh/setup-uv](https://github.com/astral-sh/setup-uv) | [`v9.0.0` → `v10.0.1`](https://github.com/astral-sh/setup-uv/compare/v9.0.0...v10.0.1) | 2026-08-14 (2 weeks ago) |

### Release notes

<details>
<summary><code>astral-sh/setup-uv</code></summary>

#### [`v10.0.0`](https://github.com/astral-sh/setup-uv/releases/tag/v10.0.0)

##### Changes

Another breaking release, directly after v9.0.0 but we think the added security justifies that.

###### Extra security by default

If you use the default `enable-cache: auto` this will now **DISABLE THE CACHE** to protect against cache poisoning for the following events:

- `pull_request_target`
- `workflow_run`
- `release`

You can read the full reasoning in https://redirect.github.com/astral-sh/setup-uv/issues/984

###### `version: latest-known`

```yaml
- name: Install the latest version of uv known to setup-uv
  uses: astral-sh/setup-uv@v10.0.0
  with:
    version: "latest-known"
```

This will now install the latest version with a checksum that is known by this action. The [known `uv` checksums](https://redirect.github.com/astral-sh/setup-uv/blob/4f6036f71cec78afb113b323f220c9185d983c12/src/download/checksum/known-checksums.ts) are automatically updated but will take a release of this action to take effect. You won't be always using the latest & greatest but you will have an extra level of security.

###### Read python version from `.tool-versions`

```yaml
- name: Install uv based on the version defined in .tool-versions and also set python
  uses: astral-sh/setup-uv@v10.0.0
  with:
    version-file: "pyproject.toml"
```

Will now also set the python version if it is defined in `.tool-versions`. You can read the details [in the docs](https://redirect.github.com/astral-sh/setup-uv/blob/main/docs/advanced-version-configuration.md#install-a-version-defined-in-a-requirements-or-config-file)

##### 🚨 Breaking changes

- Disable automatic caching for sensitive events @​eifinger (#​992)

##### 🐛 Bug fixes

- Reject paths in .tool-versions @​eifinger (#​1007)

##### 🚀 Enhancements

- Read Python version from .tool-versions @​eifinger (#​996)
- Add latest-known version selector @​eifinger (#​993)

##### 🧰 Maintenance

- Require pull requests for Dependabot rollups @​eifinger (#​1005)

... [Full release notes](https://github.com/astral-sh/setup-uv/releases/tag/v10.0.0)

#### [`v10.0.1`](https://github.com/astral-sh/setup-uv/releases/tag/v10.0.1)

##### Changes

Thank you @​arguile- for making this action more resilient.

##### 🐛 Bug fixes

- Tolerate transient manifest timeouts @​arguile- (#​1016)

##### 🧰 Maintenance

- chore: update known checksums for 0.12.4 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​1017)

##### 📚 Documentation

- docs: update version references to v10.0.0 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​1014)

</details>

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://repomatic.net/configuration) options:

- [`action-pins.sync`](https://repomatic.net/configuration#action-pins-sync)
- [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-action-pins`](https://repomatic.net/workflows#sync-action-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`492a3693`](https://github.com/kdeldycke/extra-platforms/commit/492a3693fefc859208809d86aeb41978f2e136da)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/extra-platforms/blob/492a3693fefc859208809d86aeb41978f2e136da/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/extra-platforms/blob/492a3693fefc859208809d86aeb41978f2e136da/.github/workflows/autofix.yaml)
- **Run**: [#919.1](https://github.com/kdeldycke/extra-platforms/actions/runs/33149944606)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.14.0`
