### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -245,14 +245,11 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.4.2"
+version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
 ]
 
 [[package]]
@@ -563,11 +560,11 @@ wheels = [
 
 [[package]]
 name = "imagesize"
-version = "2.0.0"
+version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3", size = 1773045, upload-time = "2026-03-03T14:18:29.941Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/5e/513ff06670c84e7b9887c1fdf61b2d42b4f574a831f2f1d2222023049d8a/imagesize-2.0.1.tar.gz", hash = "sha256:b2ba6a4dea487a7ebcd53248d3476aca449d30db12a2dde5e0c5ca9624fd77e5", size = 1883774, upload-time = "2026-08-24T12:35:19.13Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96", size = 9441, upload-time = "2026-03-03T14:18:27.892Z" },
+    { url = "https://files.pythonhosted.org/packages/01/f9/575c8d760eae1fc99651b7cc5efd96ad5379ca4d6b53750b0fb4fe983f34/imagesize-2.0.1-py3-none-any.whl", hash = "sha256:ea0c9a0384df69ed86a943a15cde37d0360b82491b3910dc2215e202e62b5b02", size = 14794, upload-time = "2026-08-24T12:35:12.548Z" },
 ]
 
 [[package]]
@@ -991,14 +988,14 @@ wheels = [
 
 [[package]]
 name = "sphinx-autodoc-typehints"
-version = "3.13.2"
+version = "3.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/5f/7f2a768683c24dac122d6d9714b923ed84d87ffde058a37d525996687295/sphinx_autodoc_typehints-3.13.2.tar.gz", hash = "sha256:ea20b9a217b86391b0ece262c4336e3c2f476fe1f76028635d550b4e74cd7498", size = 88492, upload-time = "2026-08-03T22:26:01.344Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/87/71b5530a4657d5dda36742907d6ba77c63db724a9099eda5e114a62016b4/sphinx_autodoc_typehints-3.13.4.tar.gz", hash = "sha256:9429680faa192fec9797edb9575923177f9d2ab277481d561d4cbd4aeb9cd472", size = 92020, upload-time = "2026-08-24T15:37:44.181Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/53/7ae6f44d2a9275562ff6fb7cf8be14c35e8ab057ebd4954f9f10558efb0d/sphinx_autodoc_typehints-3.13.2-py3-none-any.whl", hash = "sha256:b2a7b531369a128c7c52867962fe224d89a1d480a462a314621c710a7d6e3ecf", size = 44836, upload-time = "2026-08-03T22:26:00.029Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/10/bc3e16cda1241b45f34bbec5e3728d386e45c831798d0e45da57d2023aae/sphinx_autodoc_typehints-3.13.4-py3-none-any.whl", hash = "sha256:05c9fa3bc312cb576a16a4b2e53459c170e540665687049a0d142a83736f5209", size = 45801, upload-time = "2026-08-24T15:37:43.004Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-08-27`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click](https://pypi.org/project/click/) | [`8.4.2` → `8.5.0`](https://github.com/pallets/click/compare/8.4.2...8.5.0) | 2026-08-26 (a week ago) |
| [imagesize](https://pypi.org/project/imagesize/) | [`2.0.0` → `2.0.1`](https://github.com/shibukawa/imagesize_py/compare/2.0.0...2.0.1) | 2026-08-24 (a week ago) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | [`3.13.2` → `3.13.4`](https://github.com/tox-dev/sphinx-autodoc-typehints/compare/3.13.2...3.13.4) | 2026-08-24 (a week ago) |

### Release notes

<details>
<summary><code>click</code></summary>

#### [`8.5.0`](https://github.com/pallets/click/releases/tag/8.5.0)

This is the Click 8.5.0 feature release. A feature release may include new features, remove previously deprecated code, add new deprecation, or introduce potentially breaking changes.

We encourage everyone to upgrade. You can read more about our [Version Support Policy][version] on our website.

[version]: https://palletsprojects.com/versions

PyPI: https://pypi.org/project/click/8.5.0/
Changes:  https://click.palletsprojects.com/page/changes/#version-8-5-0
Milestone https://redirect.github.com/pallets/click/milestone/33

- Add built-in shell completion support for PowerShell (Windows PowerShell
  5.1+ and pwsh 7+) alongside the existing `bash`, `zsh`, and `fish`
  completers. Use `_FOO_BAR_COMPLETE=powershell_source foo-bar` to generate
  the completion script. #​2672 #​3637
- Supported versions of Windows enable ANSI terminal styles by default.
  Colorama is no longer a dependency and is not used. #​2986 #​3505
- {class}`Argument` accepts a `help` parameter, and help output includes
  a `Positional arguments` section when argument help is available. #​2983 #​3473
- `confirm()` and `prompt()` strip ANSI color and style codes from the
  prompt when the output stream does not support them, matching `echo()`.
  This stripping was lost in `8.4.0` when #​2969 began writing the
  prompt with `input()` directly. #​3572 #​3653
- {class}`Path` with `allow_dash=True` no longer triggers a `BytesWarning`,
  an error under `python -bb`, when checking a value against the `-`
  convention. #​2877 #​3642
- Add {func}`custom_version_option`, a `--version` option whose output is
  produced by a callback, covering cases {func}`version_option` intentionally
  does not. The feature set of {func}`version_option` is now frozen; see
  [discussion #​3527](https://redirect.github.com/pallets/click/discussions/3527). #​3581
- `style()` and `secho()` no longer silently drop the 256-color index `0`

... [Full release notes](https://github.com/pallets/click/releases/tag/8.5.0)

</details>

<details>
<summary><code>imagesize</code></summary>

#### [`2.0.1`](https://github.com/shibukawa/imagesize_py/releases/tag/2.0.1)

- Optimize metadata parsing and HTTP range reads.
- Fix JPEG2000 box parsing.
- Accept single-quoted SVG dimensions.
- Return positive heights for top-down BMP images.
- Remove the upper Python version cap, migrate packaging to pyproject.toml,
  and add Python 3.15 CI coverage.
- Bump the package version to 2.0.1 and add recent feedback contributors to
  the README.

Related issues:
https://redirect.github.com/shibukawa/imagesize_py/issues/64
https://redirect.github.com/shibukawa/imagesize_py/issues/83
https://redirect.github.com/shibukawa/imagesize_py/issues/84

Related pull requests:
https://redirect.github.com/shibukawa/imagesize_py/pull/86
https://redirect.github.com/shibukawa/imagesize_py/pull/87
https://redirect.github.com/shibukawa/imagesize_py/pull/88
https://redirect.github.com/shibukawa/imagesize_py/pull/89
https://redirect.github.com/shibukawa/imagesize_py/pull/90
https://redirect.github.com/shibukawa/imagesize_py/pull/91
https://redirect.github.com/shibukawa/imagesize_py/pull/92

</details>

<details>
<summary><code>sphinx-autodoc-typehints</code></summary>

#### [`3.13.3`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.13.3)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🔧 chore: batch dependency updates weekly on Tuesday by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/755
* 🐛 fix(parser): stop shadowing intersphinx roles in the rtype probe by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/756
* 🐛 fix(resolver): accept guarded code the interpreter rejects by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/757
* 🐛 fix(docstring): survive a re-entrant docstring handler by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/758

**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.13.2...3.13.3

#### [`3.13.4`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.13.4)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🐛 fix(parser): stop shadowing intersphinx roles in the type role by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/761
* 🐛 fix(resolver): bind only what a guarded statement defines by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/760
* 🧪 test(docstring): pin what a nested handler restores by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/759

**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.13.3...3.13.4

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.9.1` | `9.1.0` | 2026-09-03 (just now) | 2026-09-10 (in a week) |
| [coverage](https://pypi.org/project/coverage/) | `7.15.4` | `7.16.0` | 2026-08-28 (6 days ago) | 2026-09-04 (in a day) |
| [deepmerge](https://pypi.org/project/deepmerge/) | `3.0` | `3.0.1` | 2026-09-01 (2 days ago) | 2026-09-08 (in 5 days) |
| [pytest-randomly](https://pypi.org/project/pytest-randomly/) | `4.1.0` | `5.0.0` | 2026-09-01 (2 days ago) | 2026-09-08 (in 5 days) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.13.4` | `3.13.5` | 2026-09-01 (2 days ago) | 2026-09-08 (in 5 days) |
| [sphinxcontrib-mermaid](https://pypi.org/project/sphinxcontrib-mermaid/) | `2.1.0` | `2.1.1` | 2026-09-01 (2 days ago) | 2026-09-08 (in 5 days) |
| [wcwidth](https://pypi.org/project/wcwidth/) | `0.8.2` | `0.8.3` | 2026-08-28 (6 days ago) | 2026-09-04 (in a day) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://repomatic.net/configuration) options:

- [`uv-lock.sync`](https://repomatic.net/configuration#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://repomatic.net/workflows#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`4cb48c9c`](https://github.com/kdeldycke/extra-platforms/commit/4cb48c9c3f3eaa042cb5d2730fc22d80b9e8bb7b)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/extra-platforms/blob/4cb48c9c3f3eaa042cb5d2730fc22d80b9e8bb7b/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/extra-platforms/blob/4cb48c9c3f3eaa042cb5d2730fc22d80b9e8bb7b/.github/workflows/autofix.yaml)
- **Run**: [#935.1](https://github.com/kdeldycke/extra-platforms/actions/runs/33761017684)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.14.0`
