### PR TITLE
[changelog] Bump minor version to `v13.9.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [`13.8.1.dev0` (unreleased)](https://github.com/kdeldycke/extra-platforms/compare/v13.8.0...main)
+## [`13.9.0.dev0` (unreleased)](https://github.com/kdeldycke/extra-platforms/compare/v13.8.0...main)
 
 > [!WARNING]
 > This version is **not released yet** and is under active development.

--- a/citation.cff
+++ b/citation.cff
@@ -8,6 +8,6 @@ authors:
     email: kevin@deldycke.com
     orcid: "https://orcid.org/0000-0001-9748-9014"
 doi: 10.5281/zenodo.13341712
-version: 13.8.1.dev0
+version: 13.9.0.dev0
 date-released: 2026-09-07
 url: "https://github.com/kdeldycke/extra-platforms"

--- a/extra_platforms/__init__.py
+++ b/extra_platforms/__init__.py
@@ -428,7 +428,7 @@ Pytest optional.
 """
 
 
-__version__ = "13.8.1.dev0"
+__version__ = "13.9.0.dev0"
 
 
 def _initialize_group_detection_functions() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "uv-build>=0.8" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "extra-platforms"
-version = "13.8.1.dev0"
+version = "13.9.0.dev0"
 description = "🔎 Detect architectures, platforms, shells, terminals, CI systems and agents, grouped by family"
 readme = "readme.md"
 keywords = [
@@ -264,7 +264,7 @@ optional-dependencies.pytest = [
 ]
 urls.Changelog = "https://github.com/kdeldycke/extra-platforms/blob/main/changelog.md"
 urls.Documentation = "https://kdeldycke.github.io/extra-platforms"
-urls.Download = "https://github.com/kdeldycke/extra-platforms/releases/tag/v13.8.1.dev0"
+urls.Download = "https://github.com/kdeldycke/extra-platforms/releases/tag/v13.9.0.dev0"
 urls.Funding = "https://github.com/sponsors/kdeldycke"
 urls.Homepage = "https://github.com/kdeldycke/extra-platforms"
 urls.Issues = "https://github.com/kdeldycke/extra-platforms/issues"
@@ -497,7 +497,7 @@ report.fail_under = 30
 report.precision = 2
 
 [tool.bumpversion]
-current_version = "13.8.1.dev0"
+current_version = "13.9.0.dev0"
 # Parse versions with an optional .devN suffix (PEP 440).
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\.dev(?P<dev>\\d+))?"
 serialize = [

--- a/uv.lock
+++ b/uv.lock
@@ -473,7 +473,7 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "13.8.1.dev0"
+version = "13.9.0.dev0"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Ready to be merged into `main` branch, at the discretion of the maintainers, to bump the minor part of the version number. Version bumps are scheduled daily and also triggered after releases. See the [`bump-version` job documentation](https://repomatic.net/workflows#github-workflows-changelog-yaml-jobs) for details.

## To bump version to `v13.9.0`

1. **Click `Ready for review`** button below, to get this PR out of `Draft` mode

2. **Click `Rebase and merge`** button below


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/extra-platforms/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`bump-version`](https://repomatic.net/workflows#bump-version-bump-version)
- **Trigger**: `workflow_run`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`841743c1`](https://github.com/kdeldycke/extra-platforms/commit/841743c192a591a7effe253463b97d7107c4c16d)
- **Job**: [`bump-version`](https://github.com/kdeldycke/extra-platforms/blob/841743c192a591a7effe253463b97d7107c4c16d/.github/workflows/changelog.yaml)
- **Workflow**: [`changelog.yaml`](https://github.com/kdeldycke/extra-platforms/blob/841743c192a591a7effe253463b97d7107c4c16d/.github/workflows/changelog.yaml)
- **Run**: [#842.1](https://github.com/kdeldycke/extra-platforms/actions/runs/34143062284)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.14.0`
